### PR TITLE
Bump near-accounting-export: NEAR Intents transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gateway-pin",
+  "name": "ariz-gw-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#b28d8b8",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#dbe8b53",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#b28d8b8b7c177399188a2efc3d252d79c5315625",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#dbe8b53ad854a135930d43010b98e08fa058712f",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#b28d8b8",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#dbe8b53",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the `near-accounting-export` pin to `dbe8b53` (PeterSalomonsen/near-accounting-export#47).

Picks up NEP-245 NEAR Intents balance ingestion from the FastNear Transfers API, recovering intents deposits — e.g. NPRO moved into NEAR Intents — that the legacy path dropped (validated: intents NPRO deposits 7 → 48, all 34 May days; total owned continuity gaps 70 → 1; FT/NEAR/staking unchanged).

On deploy the worker re-runs its one-time per-account backfill (`FT_BACKFILL_VERSION=2`) on the first forward cycle, then continues incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)