### PR TITLE
Bump near-accounting-export: purge synthetic gap records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gw-2",
+  "name": "ariz-gw-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#dbe8b53",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#642fb0c",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#dbe8b53ad854a135930d43010b98e08fa058712f",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#642fb0c6e3163ea58e441118ab2e979a1d4d7153",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#dbe8b53",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#642fb0c",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the pin to `642fb0c` (PeterSalomonsen/near-accounting-export#48).

Stops synthesizing null-timestamp gap records and purges existing ones on re-backfill (`FT_BACKFILL_VERSION=3`). Fixes the frontend **load from server** crash (`Cannot read properties of null (reading 'toString')`) — petersalomonsen.near had 27 such records from the prior backfill; the worker re-backfills and removes them on the next cycle after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)