### PR TITLE
Bump near-accounting-export: complete balance-change history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gw-3",
+  "name": "ariz-gw-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#642fb0c",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#afddf12",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#642fb0c6e3163ea58e441118ab2e979a1d4d7153",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#afddf12284b34121384275d9f8a5972144d14c52",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#642fb0c",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#afddf12",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the pin to `afddf12` (PeterSalomonsen/near-accounting-export#49 + CI split #50).

Backfill now adopts the full FastNear transfer ledger for FT + intents tokens and fills the API's block-level gaps with the balance-tracker's non-transfer mint/burn records — every balance-changing transaction captured. Validated on live data: 0 block-level gaps across all owned tokens. Worker re-backfills (`FT_BACKFILL_VERSION=5`) on the next cycle after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)