### PR TITLE
Bump near-accounting-export: capture NEAR transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gw-4",
+  "name": "ariz-gw-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#afddf12",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#0ac387d",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#afddf12284b34121384275d9f8a5972144d14c52",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#0ac387dcdb217f976ab1b4cce1a57b2ca06fdcff",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#afddf12",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#0ac387d",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the pin to `0ac387d` (PeterSalomonsen/near-accounting-export#51).

Fills the balance-tracker's NEAR ledger gaps with the FastNear transfers API's `native:near` transfers — captures cross-contract DAO/treasury moves the tracker dropped (validated: +326 NEAR transfers on petersalomonsen.near, no double-counting). Worker re-backfills (`FT_BACKFILL_VERSION=6`) on the next cycle after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)