### PR TITLE
Bump near-accounting-export: preserve ftBackfillVersion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gw-5",
+  "name": "ariz-gw-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#0ac387d",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#3261aa4",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#0ac387dcdb217f976ab1b4cce1a57b2ca06fdcff",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#3261aa470d242eb05501825b0f1ef1eb7c2d64cb",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#0ac387d",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#3261aa4",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps pin to `3261aa4` (PeterSalomonsen/near-accounting-export#52). Stops the perpetual full re-backfill for history-incomplete/active accounts (the balance-tracker was dropping the marker on save), reducing sustained FastNear traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)