### PR TITLE
Bump near-accounting-export: incremental boundary includes NEAR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ariz-gw-6",
+  "name": "gw7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#3261aa4",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#5ac2da6",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#3261aa470d242eb05501825b0f1ef1eb7c2d64cb",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#5ac2da6dbf2ed0b83efbe6c0f62b5190297d8a30",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#3261aa4",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#5ac2da6",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps pin to `5ac2da6` (#53). Trims the transfers-API over-fetch (NEAR-only/stale-FT accounts were re-fetching full transfer history each cycle). No output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)