### PR TITLE
Bump near-accounting-export: request metrics (diagnostic)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gw7",
+  "name": "gw8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#5ac2da6",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#05265e7",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#5ac2da6dbf2ed0b83efbe6c0f62b5190297d8a30",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#05265e7f715b9bd38870f3d54ad722fb24594f49",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#5ac2da6",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#05265e7",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps pin to `05265e7` (#55). Adds per-cycle outbound-request-by-host logging to diagnose the FastNear usage. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)