### PR TITLE
Bump near-accounting-export: complete incomplete accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gw8",
+  "name": "gw9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#05265e7",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#d79d3ea",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,7 +1393,7 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#05265e7f715b9bd38870f3d54ad722fb24594f49",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#d79d3eaa67a93ed1c2d1da8bf670956a4676e9d6",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#05265e7",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#d79d3ea",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps pin to `d79d3ea` (#57). Completes the 4 perpetually-incomplete accounts via the NEAR tx-index builder and marks them complete, stopping the backward binary search — the ~94%-archival-RPC steady-state hotspot. Validated on-chain (final balances exact, 0 gaps). Metrics will show the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)