### PR TITLE
Gateway-owned enrollment/sync gate (require ARIZ authorization + balance)

### DIFF
--- a/server/arizcredits/authorization.js
+++ b/server/arizcredits/authorization.js
@@ -1,0 +1,43 @@
+import nearApi from 'near-api-js';
+
+/**
+ * Build a read-only checker that decides whether an account may be enrolled/
+ * synced: it must have an active `authorize_deduction` (operator = the contract
+ * account) AND a positive ARIZ balance. Results are cached per account with a
+ * short TTL to bound RPC. No signing key required.
+ *
+ * @param {object} cfg
+ * @param {string} cfg.networkId
+ * @param {string} cfg.nodeUrl
+ * @param {string} cfg.contractId   arizcredits.near (also the operator account)
+ * @param {number} [cfg.ttlMs]
+ */
+export async function createAuthorizationChecker({ networkId, nodeUrl, contractId, ttlMs = 5 * 60 * 1000 }) {
+    const near = await nearApi.connect({ networkId, nodeUrl });
+    const account = await near.account(contractId); // view-only; no key needed
+    const view = new nearApi.Contract(account, contractId, {
+        viewMethods: ['view_js_func', 'ft_balance_of'],
+    });
+    const cache = new Map(); // accountId -> { ok, expiresAt }
+
+    // Resolves true (authorised + funded) / false (definitively not), and
+    // THROWS on RPC/parse failure so callers can distinguish "not allowed" from
+    // "couldn't check" (request gate fails closed; reconciliation never prunes on
+    // error). Only definitive results are cached.
+    return async function isAuthorizedAndFunded(accountId) {
+        const cached = cache.get(accountId);
+        if (cached && cached.expiresAt > Date.now()) return cached.ok;
+        const auth = await view.view_js_func({
+            function_name: 'view_authorisation',
+            user: accountId,
+            operator_account: contractId,
+        });
+        let ok = false;
+        if (auth) {
+            const balance = await view.ft_balance_of({ account_id: accountId });
+            ok = BigInt(balance || '0') > 0n;
+        }
+        cache.set(accountId, { ok, expiresAt: Date.now() + ttlMs });
+        return ok;
+    };
+}

--- a/server/arizcredits/enrollment.js
+++ b/server/arizcredits/enrollment.js
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Gateway-owned enrollment policy. The near-accounting-export library stays
+// generic (it just syncs whatever accounts are listed in accounts.json); the
+// gateway decides membership here. This keeps all Ariz/billing knowledge in the
+// gateway and out of the library.
+
+/**
+ * Remove accounts that no longer qualify from the worker's accounts.json, so the
+ * background sync stops processing (and incurring FastNear cost for) them.
+ *
+ * Fail-safe: an account is pruned only when `isAllowed` resolves a definitive
+ * `false`. If the check throws (e.g. transient RPC failure) the account is kept,
+ * so a blip never bulk-wipes the enrolled set.
+ *
+ * @param {string} dataDir
+ * @param {(accountId: string) => Promise<boolean>} isAllowed
+ * @returns {Promise<string[]>} the account ids that were pruned
+ */
+export async function pruneAccounts(dataDir, isAllowed) {
+    const file = path.join(dataDir, 'accounts.json');
+    if (!fs.existsSync(file)) return [];
+    let db;
+    try {
+        db = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+        return [];
+    }
+    const accounts = db.accounts || {};
+    const pruned = [];
+    for (const id of Object.keys(accounts)) {
+        let allowed;
+        try {
+            allowed = await isAllowed(id);
+        } catch {
+            continue; // couldn't verify -> keep (don't prune on error)
+        }
+        if (allowed === false) {
+            delete accounts[id];
+            pruned.push(id);
+        }
+    }
+    if (pruned.length) {
+        db.accounts = accounts;
+        fs.writeFileSync(file, JSON.stringify(db, null, 2));
+    }
+    return pruned;
+}

--- a/server/arizcredits/enrollment.test.js
+++ b/server/arizcredits/enrollment.test.js
@@ -1,0 +1,45 @@
+import { describe, test, beforeEach } from 'node:test';
+import { deepEqual } from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pruneAccounts } from './enrollment.js';
+
+function writeAccounts(dir, ids) {
+    const accounts = {};
+    for (const id of ids) accounts[id] = { accountId: id, registeredAt: 'x' };
+    writeFileSync(join(dir, 'accounts.json'), JSON.stringify({ accounts }));
+}
+const idsIn = (dir) => Object.keys(JSON.parse(readFileSync(join(dir, 'accounts.json'), 'utf8')).accounts).sort();
+
+describe('pruneAccounts', () => {
+    let dir;
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ariz-enroll-')); });
+
+    test('prunes only the disallowed accounts', async () => {
+        writeAccounts(dir, ['a.near', 'b.near', 'c.near']);
+        const allowed = new Set(['a.near', 'c.near']);
+        const pruned = await pruneAccounts(dir, async (id) => allowed.has(id));
+        deepEqual(pruned, ['b.near']);
+        deepEqual(idsIn(dir), ['a.near', 'c.near']);
+    });
+
+    test('no-op when all allowed', async () => {
+        writeAccounts(dir, ['a.near', 'b.near']);
+        const pruned = await pruneAccounts(dir, async () => true);
+        deepEqual(pruned, []);
+        deepEqual(idsIn(dir), ['a.near', 'b.near']);
+    });
+
+    test('fail-safe: keeps accounts when the check throws (RPC error)', async () => {
+        writeAccounts(dir, ['a.near', 'b.near']);
+        const pruned = await pruneAccounts(dir, async () => { throw new Error('rpc down'); });
+        deepEqual(pruned, []);
+        deepEqual(idsIn(dir), ['a.near', 'b.near'], 'a transient failure must not wipe the enrolled set');
+    });
+
+    test('missing accounts.json returns []', async () => {
+        const pruned = await pruneAccounts(dir, async () => false);
+        deepEqual(pruned, []);
+    });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ import { createRpcHandler } from './rpc.js';
 import { createRouter as createAccountingRouter, startWorker as startAccountingWorker } from 'near-accounting-export';
 import { createDeductClient } from './arizcredits/deduct.js';
 import { createBillingPass } from './arizcredits/billing.js';
+import { createAuthorizationChecker } from './arizcredits/authorization.js';
+import { pruneAccounts } from './arizcredits/enrollment.js';
 
 const SERVER_PORT = process.env.ARIZ_GATEWAY_PORT ?? 15000;
 const contractId = process.env.ARIZ_GATEWAY_CONTRACT_ID ?? 'arizportfolio.testnet';
@@ -28,6 +30,15 @@ if (!process.env.NEAR_RPC_ENDPOINT) {
 
 const auth = await createAuthMiddleware({ networkId, contractId, nodeUrl });
 const handleRpc = createRpcHandler({ nodeUrl });
+
+// Billing is enabled only when an operator key + a positive per-request rate are
+// set. When enabled, we also gate enrollment + syncing on each account having an
+// active authorisation AND a positive ARIZ balance, so we never sync (incur
+// FastNear cost for) accounts that aren't paying.
+const billingEnabled = !!(process.env.ARIZCREDITS_OPERATOR_KEY && arizPerFastNearRequest && BigInt(arizPerFastNearRequest) > 0n);
+const accountGate = billingEnabled
+    ? await createAuthorizationChecker({ networkId, nodeUrl, contractId: arizCreditsContractId })
+    : null;
 
 function splitList(value) {
     return (value ?? '').split(',').map(s => s.trim()).filter(Boolean);
@@ -68,15 +79,25 @@ app.get('/api/prices/current', auth, async (req, res) => {
 
 app.post('/rpc', auth, handleRpc);
 
-// Path-based account selection: any authenticated user can request data
-// for any accountId. Account ownership isn't cryptographically verifiable
-// at the gateway, so read access is open to all signed-in users.
-// Worker enrollment (which accounts the background sync actually processes)
-// is the place to apply restrictions like a payment gate; that's a follow-up.
-app.use('/api/accounting/:accountId', auth, (req, _res, next) => {
+// Path-based account selection. When billing is on, the gateway gates accounting
+// access (and therefore enrollment/syncing) on the account having an active
+// authorisation + ARIZ balance — an unauthorised account gets 402 and never
+// reaches the lazy-enrollment in the (Ariz-agnostic) accounting router.
+app.use('/api/accounting/:accountId', auth, async (req, res, next) => {
     // Express resets req.params when entering a mounted router, so stash
     // the path-derived accountId on req for the upstream getAccountId hook.
     req.targetAccountId = req.params.accountId;
+    if (accountGate) {
+        let allowed = false;
+        try { allowed = await accountGate(req.params.accountId); } catch { allowed = false; } // fail closed
+        if (!allowed) {
+            return res.status(402).json({
+                error: 'authorization_required',
+                accountId: req.params.accountId,
+                message: 'Authorize the Ariz gateway (authorize_deduction on arizcredits.near) and hold ARIZ to enable syncing for this account.',
+            });
+        }
+    }
     next();
 }, createAccountingRouter({
     getAccountId: req => req.targetAccountId,
@@ -104,11 +125,30 @@ if (process.env.ARIZ_GATEWAY_DISABLE_ACCOUNTING_WORKER !== 'true') {
     accountingWorker = await startAccountingWorker({ dataDir });
 }
 
+// Enrollment reconciliation: periodically prune accounts that no longer qualify
+// (authorisation revoked / out of ARIZ) from the worker's account list, so the
+// background sync stops syncing them. Pairs with the request-time 402 gate above
+// (which keeps new unauthorised accounts out). Gateway-owned policy; the library
+// just syncs whatever remains listed.
+let reconcileTimer = null;
+if (billingEnabled && accountGate) {
+    const reconcile = async () => {
+        try {
+            const pruned = await pruneAccounts(dataDir, accountGate);
+            if (pruned.length) console.log(`[enrollment] pruned ${pruned.length} unauthorised account(s): ${pruned.join(', ')}`);
+        } catch (e) {
+            console.error('[enrollment] reconciliation failed:', e);
+        }
+    };
+    await reconcile();
+    reconcileTimer = setInterval(reconcile, 60 * 60 * 1000); // hourly
+}
+
 // Daily ARIZ usage-billing pass. The worker records per-account FastNear request
 // metrics; this pass converts the unbilled delta to ARIZ and deducts it in one
 // batched call once per UTC day. All billing state lives in the gateway.
 let billingTimer = null;
-if (process.env.ARIZCREDITS_OPERATOR_KEY && arizPerFastNearRequest && BigInt(arizPerFastNearRequest) > 0n) {
+if (billingEnabled) {
     const deductClient = await createDeductClient({
         networkId,
         nodeUrl,
@@ -150,6 +190,9 @@ async function shutdown() {
     server.close();
     if (billingTimer) {
         clearInterval(billingTimer);
+    }
+    if (reconcileTimer) {
+        clearInterval(reconcileTimer);
     }
     if (accountingWorker) {
         await accountingWorker.stop();


### PR DESCRIPTION
## Summary

Closes the cost-recovery gap: previously any logged-in user could trigger enrollment + background syncing of any account (real FastNear cost), while only authorized accounts were billed. Now, when billing is enabled, an account is enrolled/synced **only** if it has an active `authorize_deduction` (operator = `arizcredits.near`) **and** a positive ARIZ balance.

**All gating lives in the gateway** — `near-accounting-export` stays a generic, Ariz-agnostic library (no changes; the earlier worker-hook PR was closed in favour of this).

- `authorization.js` — read-only checker (authorisation + ARIZ balance), throws on RPC error so callers choose the failure mode; 5-min TTL cache.
- `index.js` request gate — `/api/accounting/:accountId` returns **402** for non-qualifying accounts, so the library's lazy-enrollment never runs for them (fail **closed** on error).
- `enrollment.js` + hourly reconciliation — prunes accounts that no longer qualify (revoked / out of ARIZ) from the worker's `accounts.json`, so syncing stops. Fail-**safe**: never prunes on an RPC error (a blip can't wipe the enrolled set).

Gate is inactive unless billing is enabled (`ARIZCREDITS_OPERATOR_KEY` + `ARIZ_PER_FASTNEAR_REQUEST`), so non-billing deployments are unaffected.

## Tests
34 unit (incl. 4 new `pruneAccounts` tests covering prune / no-op / fail-safe-on-error / missing-file) + 9 integration. All green.

## Note on existing accounts
With billing live, accounts already in `accounts.json` that haven't authorized will be pruned on the first reconciliation (intended — they must authorize + hold ARIZ to keep syncing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)