### PR TITLE
Payer model: one account pays for monitoring many

### DIFF
--- a/server/arizcredits/billing.js
+++ b/server/arizcredits/billing.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { readFastNearMetrics } from 'near-accounting-export';
+import { loadMonitors } from './monitors.js';
 
 // FastNear hosts that cost credits. The free tx-index API (tx.main.fastnear.com)
 // is intentionally excluded.
@@ -20,15 +21,14 @@ function sumBillable(byHost, billableHosts) {
 }
 
 /**
- * The gateway-owned daily billing pass. All billing state lives here; the worker
- * is metrics-only.
+ * The gateway-owned daily billing pass.
  *
- * Each run: read the worker's cumulative per-account FastNear request counts,
- * compute each account's unbilled delta vs a persisted watermark, gate on an
- * active authorisation, clamp the amount to the user's daily cap, and deduct the
- * batch in one transaction. Watermarks advance only for accounts the contract
- * reports as charged, so it's idempotent and restart-safe (re-running the same
- * UTC day is a no-op).
+ * Usage is measured per monitored account (the worker's FastNear metrics), but
+ * charged to that account's PAYER (monitors.json). Each run: compute each
+ * account's unbilled delta vs a persisted per-account watermark, group by payer,
+ * and deduct once per payer (bounded by the payer's daily cap) in one batched
+ * transaction. Per-account watermarks advance only for the portion actually
+ * charged, so a capped overflow rolls to the next day. Idempotent / restart-safe.
  *
  * @param {object} cfg
  * @param {string} cfg.dataDir
@@ -49,71 +49,86 @@ export function createBillingPass({ dataDir, deductClient, ratePerRequest, billa
         fs.writeFileSync(billingFile, JSON.stringify(db, null, 2));
     }
 
-    /** True if the daily pass hasn't run yet for the current UTC day. */
     function shouldRun(now = Date.now()) {
         return load().lastRunDay !== utcDay(now);
     }
 
     async function runOnce({ now = Date.now() } = {}) {
-        const metrics = readFastNearMetrics(dataDir); // { accountId: { host: count } }
+        const metrics = readFastNearMetrics(dataDir); // { account: { host: count } }
+        const monitors = loadMonitors(dataDir);       // { account: payer }
         const db = load();
         db.accounts = db.accounts || {};
 
-        // Build candidate deductions (delta vs watermark, gated + cap-clamped).
-        const candidates = [];
-        for (const [accountId, byHost] of Object.entries(metrics)) {
-            const billableTotal = sumBillable(byHost, billableHosts);
-            const state = db.accounts[accountId] || { billedRequests: 0 };
-            const deltaRequests = billableTotal - (state.billedRequests || 0);
-            if (deltaRequests <= 0) continue;
-
-            let auth = null;
-            try { auth = await deductClient.viewAuthorisation(accountId); } catch { auth = null; }
-            if (!auth) continue; // no active authorisation -> skip
-
-            let amount = rate * BigInt(deltaRequests);
-            const cap = BigInt(auth.max_per_day || '0');
-            if (cap > 0n && amount > cap) amount = cap; // clamp to the user's daily cap
-            if (amount <= 0n) continue;
-
-            // Requests covered by the (possibly clamped) amount — the watermark
-            // only advances by this much, so a capped overflow bills next day.
-            const billedRequestsEquivalent = rate > 0n ? Number(amount / rate) : deltaRequests;
-            candidates.push({ accountId, amount: amount.toString(), billedRequestsEquivalent });
+        // 1. Per-account unbilled delta, grouped by payer.
+        const perPayer = {}; // payer -> [{ account, delta }]
+        for (const [account, byHost] of Object.entries(metrics)) {
+            const payer = monitors[account];
+            if (!payer) continue; // unmonitored -> reconciliation will prune it
+            const billable = sumBillable(byHost, billableHosts);
+            const state = db.accounts[account] || { billedRequests: 0 };
+            const delta = billable - (state.billedRequests || 0);
+            if (delta <= 0) continue;
+            (perPayer[payer] ||= []).push({ account, delta });
         }
 
+        // 2. Per payer: clamp to the payer's daily cap, plan which accounts'
+        //    watermarks advance (greedy until the charged amount is exhausted).
+        const entries = []; // { user, amount, description }
+        const plans = {};   // payer -> [{ account, billRequests }]
+        for (const [payer, items] of Object.entries(perPayer)) {
+            let auth;
+            try { auth = await deductClient.viewAuthorisation(payer); } catch { auth = null; }
+            if (!auth) continue; // payer no longer authorised -> skip (reconciliation prunes)
+
+            const totalDelta = items.reduce((s, i) => s + i.delta, 0);
+            let amount = rate * BigInt(totalDelta);
+            const cap = BigInt(auth.max_per_day || '0');
+            if (cap > 0n && amount > cap) amount = cap;
+            if (amount <= 0n) continue;
+
+            let coveredRequests = rate > 0n ? Number(amount / rate) : totalDelta;
+            const plan = [];
+            for (const it of items) {
+                if (coveredRequests <= 0) break;
+                const take = Math.min(it.delta, coveredRequests);
+                plan.push({ account: it.account, billRequests: take });
+                coveredRequests -= take;
+            }
+            plans[payer] = plan;
+            entries.push({ user: payer, amount: amount.toString(), description: 'fastnear-usage' });
+        }
+
+        // 3. Deduct (batched, chunked), then advance watermarks for charged payers.
         const results = [];
-        for (let i = 0; i < candidates.length; i += batchSize) {
-            const chunk = candidates.slice(i, i + batchSize);
-            const deductions = chunk.map(c => ({ user: c.accountId, amount: c.amount, description: 'fastnear-usage' }));
+        for (let i = 0; i < entries.length; i += batchSize) {
+            const chunk = entries.slice(i, i + batchSize);
             let res;
             try {
-                res = await deductClient.deduct(deductions);
+                res = await deductClient.deduct(chunk);
             } catch (err) {
-                // Whole chunk failed (network/tx) — leave watermarks, retry next run.
-                res = chunk.map(c => ({ user: c.accountId, status: 'error', reason: String(err?.message || err) }));
+                res = chunk.map(e => ({ user: e.user, status: 'error', reason: String(err?.message || err) }));
             }
             const byUser = Object.fromEntries((res || []).map(r => [r.user, r]));
-            for (const c of chunk) {
-                const r = byUser[c.accountId] || { status: 'missing' };
-                // Advance the watermark when the contract charged the user (or
-                // reports an already-today charge, i.e. crash-recovery).
+            for (const e of chunk) {
+                const r = byUser[e.user] || { status: 'missing' };
                 const charged = r.status === 'deducted' || /already deducted today/.test(r.reason || '');
                 if (charged) {
-                    const state = db.accounts[c.accountId] || { billedRequests: 0 };
-                    state.billedRequests = (state.billedRequests || 0) + c.billedRequestsEquivalent;
-                    state.lastBilledAt = new Date(now).toISOString();
-                    db.accounts[c.accountId] = state;
+                    for (const item of plans[e.user] || []) {
+                        const state = db.accounts[item.account] || { billedRequests: 0 };
+                        state.billedRequests = (state.billedRequests || 0) + item.billRequests;
+                        state.lastBilledAt = new Date(now).toISOString();
+                        db.accounts[item.account] = state;
+                    }
                 }
-                results.push({ accountId: c.accountId, status: r.status, reason: r.reason, amount: c.amount });
+                results.push({ payer: e.user, status: r.status, reason: r.reason, amount: e.amount });
             }
         }
 
         db.lastRunDay = utcDay(now);
         save(db);
 
-        const deducted = results.filter(r => r.status === 'deducted');
-        return { deducted, results, total: deducted.length };
+        const charged = results.filter(r => r.status === 'deducted');
+        return { charged, results, total: charged.length };
     }
 
     return { runOnce, shouldRun };

--- a/server/arizcredits/billing.test.js
+++ b/server/arizcredits/billing.test.js
@@ -1,103 +1,111 @@
 import { describe, test, beforeEach } from 'node:test';
-import { equal, deepEqual, ok } from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { equal, deepEqual } from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createBillingPass } from './billing.js';
 
+const archival = (n) => ({ byHost: { 'archival-rpc.mainnet.fastnear.com': n } });
+
 function writeMetrics(dir, accounts) {
-    writeFileSync(join(dir, 'fastnear-metrics.json'), JSON.stringify({ accounts }, null, 2));
+    writeFileSync(join(dir, 'fastnear-metrics.json'), JSON.stringify({ accounts }));
+}
+function writeMonitors(dir, monitors) {
+    writeFileSync(join(dir, 'monitors.json'), JSON.stringify({ monitors }));
+}
+function billing(dir) {
+    return JSON.parse(readFileSync(join(dir, 'billing.json'), 'utf8'));
 }
 
-// Fake deduct client: authorises everyone except accounts in `noAuth`, with an
-// optional per-account cap. Records the batches it was asked to deduct.
-function fakeClient({ caps = {}, noAuth = new Set() } = {}) {
+// Fake deduct client: authorises payers with the given caps; records batches.
+function fakeClient({ caps = {} } = {}) {
     const calls = [];
     return {
         calls,
-        async viewAuthorisation(accountId) {
-            if (noAuth.has(accountId)) return null;
-            return { max_per_day: String(caps[accountId] ?? '0'), last_deduct_day: '', spent_today: '0' };
+        async viewAuthorisation(payer) {
+            if (!(payer in caps)) return null;
+            return { max_per_day: String(caps[payer]), last_deduct_day: '', spent_today: '0' };
         },
-        async deduct(deductions) {
-            calls.push(deductions);
-            return deductions.map(d => ({ user: d.user, status: 'deducted', amount: d.amount }));
+        async deduct(entries) {
+            calls.push(entries);
+            return entries.map(e => ({ user: e.user, status: 'deducted', amount: e.amount }));
         },
     };
 }
 
-describe('gateway billing pass', () => {
+describe('gateway billing pass (per-payer)', () => {
     let dir;
-    beforeEach(() => {
-        dir = mkdtempSync(join(tmpdir(), 'ariz-billing-'));
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ariz-billing-')); });
+
+    test('groups usage by payer and charges each payer once', async () => {
+        writeMetrics(dir, { 'x.near': archival(30), 'y.near': archival(20), 'z.near': archival(50) });
+        writeMonitors(dir, { 'x.near': 'p1.near', 'y.near': 'p1.near', 'z.near': 'p2.near' });
+        const client = fakeClient({ caps: { 'p1.near': '100000', 'p2.near': '100000' } });
+        const b = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
+
+        await b.runOnce({ now: 0 });
+
+        equal(client.calls.length, 1, 'one batched deduct');
+        const byUser = Object.fromEntries(client.calls[0].map(e => [e.user, e.amount]));
+        equal(byUser['p1.near'], '100', '(30+20)*2 for p1');
+        equal(byUser['p2.near'], '100', '50*2 for p2');
+
+        const db = billing(dir);
+        equal(db.accounts['x.near'].billedRequests, 30);
+        equal(db.accounts['y.near'].billedRequests, 20);
+        equal(db.accounts['z.near'].billedRequests, 50);
     });
 
-    test('bills the billable-host delta, excludes the free tx API, skips unauthorised', async () => {
-        writeMetrics(dir, {
-            'a.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 30, 'tx.main.fastnear.com': 1000 } },
-            'noauth.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 50 } },
-        });
-        const client = fakeClient({ noAuth: new Set(['noauth.near']) });
-        const billing = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
+    test('clamps a payer to its daily cap; advances only covered watermarks', async () => {
+        writeMetrics(dir, { 'a.near': archival(40), 'b.near': archival(40) }); // 80 reqs, rate 2 -> 160 raw
+        writeMonitors(dir, { 'a.near': 'p.near', 'b.near': 'p.near' });
+        const client = fakeClient({ caps: { 'p.near': '100' } }); // cap 100 -> 50 reqs covered
+        const b = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
 
-        const r = await billing.runOnce({ now: 0 });
+        await b.runOnce({ now: 0 });
 
-        equal(client.calls.length, 1, 'one batched deduct call');
-        // tx.main.fastnear.com is free -> excluded; 30 archival reqs * rate 2 = 60.
-        deepEqual(client.calls[0], [{ user: 'a.near', amount: '60', description: 'fastnear-usage' }]);
-        equal(r.total, 1);
-
-        const db = JSON.parse(readFileSync(join(dir, 'billing.json'), 'utf8'));
-        equal(db.accounts['a.near'].billedRequests, 30, 'watermark advanced to billed total');
-        ok(!db.accounts['noauth.near'], 'unauthorised account not billed');
+        deepEqual(client.calls[0], [{ user: 'p.near', amount: '100', description: 'fastnear-usage' }]);
+        const db = billing(dir);
+        // greedy: a.near (40) fully covered, b.near gets the remaining 10 of the 50.
+        equal(db.accounts['a.near'].billedRequests, 40);
+        equal(db.accounts['b.near'].billedRequests, 10);
     });
 
-    test('clamps the amount to the daily cap and advances the watermark proportionally', async () => {
-        writeMetrics(dir, { 'c.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 100 } } });
-        // rate 2 -> raw amount 200, but cap is 50 -> clamp; 50/2 = 25 requests billed.
-        const client = fakeClient({ caps: { 'c.near': '50' } });
-        const billing = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
+    test('skips unmonitored accounts and payers without authorisation', async () => {
+        writeMetrics(dir, { 'm.near': archival(10), 'orphan.near': archival(99) });
+        writeMonitors(dir, { 'm.near': 'noauth.near' }); // orphan.near has no payer; payer not authorised
+        const client = fakeClient({ caps: {} }); // nobody authorised
+        const b = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
 
-        await billing.runOnce({ now: 0 });
-
-        deepEqual(client.calls[0], [{ user: 'c.near', amount: '50', description: 'fastnear-usage' }]);
-        const db = JSON.parse(readFileSync(join(dir, 'billing.json'), 'utf8'));
-        equal(db.accounts['c.near'].billedRequests, 25, 'watermark advanced only by the billed (capped) portion');
+        await b.runOnce({ now: 0 });
+        equal(client.calls.length, 0, 'nothing billable');
+        equal(billing(dir).accounts['orphan.near'], undefined);
+        equal(billing(dir).accounts['m.near'], undefined);
     });
 
-    test('is idempotent: re-running with no new usage deducts nothing', async () => {
-        writeMetrics(dir, { 'a.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 10 } } });
-        const client = fakeClient();
-        const billing = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 1 });
+    test('idempotent: re-running with no new usage makes no deduct call', async () => {
+        writeMetrics(dir, { 'a.near': archival(10) });
+        writeMonitors(dir, { 'a.near': 'p.near' });
+        const client = fakeClient({ caps: { 'p.near': '100000' } });
+        const b = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
 
-        await billing.runOnce({ now: 0 });
-        await billing.runOnce({ now: 0 });
-
-        equal(client.calls.length, 1, 'second run makes no deduct call (delta is zero)');
+        await b.runOnce({ now: 0 });
+        await b.runOnce({ now: 0 });
+        equal(client.calls.length, 1, 'second run has no unbilled delta');
     });
 
-    test('bills only the incremental delta on the next run', async () => {
-        writeMetrics(dir, { 'a.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 10 } } });
-        const client = fakeClient();
-        const billing = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 1 });
-        await billing.runOnce({ now: 0 });
+    test('bills only the incremental usage on a later run', async () => {
+        writeMetrics(dir, { 'a.near': archival(10) });
+        writeMonitors(dir, { 'a.near': 'p.near' });
+        const client = fakeClient({ caps: { 'p.near': '100000' } });
+        const b = createBillingPass({ dataDir: dir, deductClient: client, ratePerRequest: 2 });
+        await b.runOnce({ now: 0 });
 
-        // more usage accrues
-        writeMetrics(dir, { 'a.near': { byHost: { 'archival-rpc.mainnet.fastnear.com': 35 } } });
-        await billing.runOnce({ now: 86_400_000 });
+        writeMetrics(dir, { 'a.near': archival(35) }); // +25 requests
+        await b.runOnce({ now: 86_400_000 });
 
         equal(client.calls.length, 2);
-        deepEqual(client.calls[1], [{ user: 'a.near', amount: '25', description: 'fastnear-usage' }]);
-        const db = JSON.parse(readFileSync(join(dir, 'billing.json'), 'utf8'));
-        equal(db.accounts['a.near'].billedRequests, 35);
-    });
-
-    test('shouldRun gates to once per UTC day', async () => {
-        writeMetrics(dir, {});
-        const billing = createBillingPass({ dataDir: dir, deductClient: fakeClient(), ratePerRequest: 1 });
-        equal(billing.shouldRun(0), true);
-        await billing.runOnce({ now: 0 });
-        equal(billing.shouldRun(0), false, 'same UTC day -> no re-run');
-        equal(billing.shouldRun(86_400_000), true, 'next UTC day -> runs again');
+        deepEqual(client.calls[1], [{ user: 'p.near', amount: '50', description: 'fastnear-usage' }]); // 25*2
+        equal(billing(dir).accounts['a.near'].billedRequests, 35);
     });
 });

--- a/server/arizcredits/monitors.js
+++ b/server/arizcredits/monitors.js
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Gateway-owned mapping of which payer account is charged for monitoring each
+// account: { [monitoredAccountId]: payerAccountId }. Persisted in monitors.json.
+// The near-accounting-export library stays generic and knows nothing about this.
+
+function monitorsFile(dataDir) {
+    return path.join(dataDir, 'monitors.json');
+}
+
+export function loadMonitors(dataDir) {
+    const f = monitorsFile(dataDir);
+    if (!fs.existsSync(f)) return {};
+    try {
+        return JSON.parse(fs.readFileSync(f, 'utf8')).monitors || {};
+    } catch {
+        return {};
+    }
+}
+
+export function saveMonitors(dataDir, monitors) {
+    fs.writeFileSync(monitorsFile(dataDir), JSON.stringify({ monitors }, null, 2));
+}
+
+/** The payer charged for monitoring `accountId`, or null. */
+export function getPayer(dataDir, accountId) {
+    return loadMonitors(dataDir)[accountId] || null;
+}
+
+/** Record that `payer` pays for monitoring `accountId` (no-op if unchanged). */
+export function setPayer(dataDir, accountId, payer) {
+    const monitors = loadMonitors(dataDir);
+    if (monitors[accountId] === payer) return;
+    monitors[accountId] = payer;
+    saveMonitors(dataDir, monitors);
+}
+
+/** Stop tracking `accountId` (drops its payer mapping). */
+export function removeMonitor(dataDir, accountId) {
+    const monitors = loadMonitors(dataDir);
+    if (!(accountId in monitors)) return;
+    delete monitors[accountId];
+    saveMonitors(dataDir, monitors);
+}

--- a/server/arizcredits/monitors.test.js
+++ b/server/arizcredits/monitors.test.js
@@ -1,0 +1,26 @@
+import { describe, test, beforeEach } from 'node:test';
+import { equal } from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getPayer, setPayer, removeMonitor, loadMonitors } from './monitors.js';
+
+describe('monitors store', () => {
+    let dir;
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ariz-monitors-')); });
+
+    test('set / get / remove a payer mapping', () => {
+        equal(getPayer(dir, 'x.near'), null);
+        setPayer(dir, 'x.near', 'p.near');
+        equal(getPayer(dir, 'x.near'), 'p.near');
+        setPayer(dir, 'y.near', 'p.near');
+        equal(Object.keys(loadMonitors(dir)).length, 2);
+        removeMonitor(dir, 'x.near');
+        equal(getPayer(dir, 'x.near'), null);
+        equal(getPayer(dir, 'y.near'), 'p.near');
+    });
+
+    test('missing file -> empty map', () => {
+        equal(getPayer(dir, 'anything.near'), null);
+    });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ import { createDeductClient } from './arizcredits/deduct.js';
 import { createBillingPass } from './arizcredits/billing.js';
 import { createAuthorizationChecker } from './arizcredits/authorization.js';
 import { pruneAccounts } from './arizcredits/enrollment.js';
+import { getPayer, setPayer, removeMonitor } from './arizcredits/monitors.js';
 
 const SERVER_PORT = process.env.ARIZ_GATEWAY_PORT ?? 15000;
 const contractId = process.env.ARIZ_GATEWAY_CONTRACT_ID ?? 'arizportfolio.testnet';
@@ -79,23 +80,37 @@ app.get('/api/prices/current', auth, async (req, res) => {
 
 app.post('/rpc', auth, handleRpc);
 
-// Path-based account selection. When billing is on, the gateway gates accounting
-// access (and therefore enrollment/syncing) on the account having an active
-// authorisation + ARIZ balance — an unauthorised account gets 402 and never
-// reaches the lazy-enrollment in the (Ariz-agnostic) accounting router.
+// Path-based account selection. When billing is on, each monitored account is
+// paid for by a payer account (monitors.json). The payer is established
+// implicitly: the first authorized + funded account that loads a not-yet-monitored
+// account becomes its payer (and is billed for it). Reads of an already-monitored
+// account stay open to any signed-in user; an unmonitored account that the caller
+// can't pay for gets 402 (and never reaches the library's lazy-enrollment).
 app.use('/api/accounting/:accountId', auth, async (req, res, next) => {
-    // Express resets req.params when entering a mounted router, so stash
-    // the path-derived accountId on req for the upstream getAccountId hook.
-    req.targetAccountId = req.params.accountId;
+    const target = req.params.accountId;
+    req.targetAccountId = target; // Express resets req.params in the mounted router
+
     if (accountGate) {
-        let allowed = false;
-        try { allowed = await accountGate(req.params.accountId); } catch { allowed = false; } // fail closed
-        if (!allowed) {
-            return res.status(402).json({
-                error: 'authorization_required',
-                accountId: req.params.accountId,
-                message: 'Authorize the Ariz gateway (authorize_deduction on arizcredits.near) and hold ARIZ to enable syncing for this account.',
-            });
+        // Is the account currently covered by a valid payer?
+        let covered = false;
+        const payer = getPayer(dataDir, target);
+        if (payer) {
+            try { covered = await accountGate(payer); } catch { covered = false; }
+        }
+        if (!covered) {
+            // Try to claim it for the authenticated requester (the payer).
+            const requester = req.accountId;
+            let canPay = false;
+            try { canPay = await accountGate(requester); } catch { canPay = false; } // fail closed
+            if (canPay) {
+                setPayer(dataDir, target, requester);
+            } else {
+                return res.status(402).json({
+                    error: 'authorization_required',
+                    accountId: target,
+                    message: 'This account is not being monitored. Log in with an account that has authorized the gateway (authorize_deduction on arizcredits.near) and holds ARIZ, then load this account to start monitoring it — you will be billed for it.',
+                });
+            }
         }
     }
     next();
@@ -132,10 +147,19 @@ if (process.env.ARIZ_GATEWAY_DISABLE_ACCOUNTING_WORKER !== 'true') {
 // just syncs whatever remains listed.
 let reconcileTimer = null;
 if (billingEnabled && accountGate) {
+    // An account stays synced only while its payer is still authorised + funded.
+    // Unmonitored accounts (no payer) are pruned too. Fail-safe: an RPC error
+    // leaves the account in place (pruneAccounts keeps accounts whose check throws).
+    const isStillPaid = async (account) => {
+        const payer = getPayer(dataDir, account);
+        if (!payer) return false;       // unmonitored -> prune
+        return accountGate(payer);      // throws on RPC error -> kept (fail-safe)
+    };
     const reconcile = async () => {
         try {
-            const pruned = await pruneAccounts(dataDir, accountGate);
-            if (pruned.length) console.log(`[enrollment] pruned ${pruned.length} unauthorised account(s): ${pruned.join(', ')}`);
+            const pruned = await pruneAccounts(dataDir, isStillPaid);
+            for (const account of pruned) removeMonitor(dataDir, account);
+            if (pruned.length) console.log(`[enrollment] pruned ${pruned.length} unpaid account(s): ${pruned.join(', ')}`);
         } catch (e) {
             console.error('[enrollment] reconciliation failed:', e);
         }


### PR DESCRIPTION
## Summary

Replaces the per-account self-payment model with a **payer model** — the account you log in with is billed for the accounts it monitors, so users authorize + fund **once** instead of per account.

- **`monitors.js`** — gateway-owned `{ monitoredAccount → payerAccount }` map.
- **Gate (`index.js`)** — the payer is established **implicitly**: the first authorized + funded account that loads a not-yet-monitored account becomes its payer (and is billed). Reads of an already-monitored account stay open to any signed-in user; an unmonitored account the caller can't pay for gets `402` (so the Ariz-agnostic library never lazily enrolls it). No new endpoint.
- **Billing (`billing.js`)** — usage is measured per monitored account but **charged to its payer**: per-account deltas are grouped by payer and deducted once per payer (bounded by the payer's daily cap; per-account watermarks advance only for the covered portion, so capped overflow rolls to the next day).
- **Reconciliation** — prunes accounts whose payer is no longer authorized/funded and drops the mapping (fail-safe on RPC errors).

The on-chain contract is unchanged (it still deducts from the payer, who authorizes once). near-accounting-export remains generic/Ariz-free.

## Tests
36 unit (per-payer billing: grouping, cap-clamp, skip-unmonitored/unauthorized, idempotency, incremental; monitors store; pruneAccounts) + 9 integration. All green.

## Pairs with
A frontend change that drops the per-account Fund/Authorize UI (#53) — the payer sets up once on the Ariz credits page; loading an account in the Accounts list bills it to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)