### PR TITLE
Prices: wNEAR→NEAR alias + CoinGecko historical fallback

### DIFF
--- a/server/api/prices.test.js
+++ b/server/api/prices.test.js
@@ -204,11 +204,54 @@ describe('prices', () => {
         equal(new URL(calls[0]).searchParams.get('ids'), 'ethereum');
     });
 
-    test('cryptocompare error surfaces to the caller', async () => {
-        globalThis.fetch = async () => jsonResponse({
-            Response: 'Error',
-            Message: 'symbol not found'
-        });
-        await rejects(() => fetchPriceHistory('UNKNOWN', 'USD'), /symbol not found/);
+    test('wNEAR is priced as NEAR (alias) and cached as near', async () => {
+        const calls = [];
+        globalThis.fetch = async (url) => {
+            const u = url.toString();
+            calls.push(u);
+            if (u.includes('cryptocompare.com')) {
+                return jsonResponse({ Response: 'Success', Data: { Data: [{ time: dayUnix('2026-06-14'), close: 4.5 }] } });
+            }
+            throw new Error(`unexpected fetch ${u}`);
+        };
+
+        const out = await fetchPriceHistory('wNEAR', 'USD');
+
+        deepEqual(out, { '2026-06-14': 4.5 });
+        const fsym = new URL(calls.find(c => c.includes('cryptocompare.com'))).searchParams.get('fsym');
+        equal(fsym, 'NEAR', 'wNEAR should be fetched as NEAR');
+        const cached = JSON.parse(await readFile(join(dataDir, 'prices', 'near.json'), 'utf8'));
+        deepEqual(cached, { '2026-06-14': 4.5 });
+        await rejects(() => readFile(join(dataDir, 'prices', 'wnear.json'), 'utf8'));
+    });
+
+    test('falls back to CoinGecko market_chart when CryptoCompare lacks the symbol', async () => {
+        globalThis.fetch = async (url) => {
+            const u = url.toString();
+            if (u.includes('cryptocompare.com')) return jsonResponse({ Response: 'Error', Message: 'fsym not found' });
+            if (u.includes('coingecko.com') && u.includes('market_chart')) {
+                return jsonResponse({ prices: [
+                    [Date.parse('2026-06-14T00:00:00Z'), 0.30],
+                    [Date.parse('2026-06-15T00:00:00Z'), 0.31]
+                ] });
+            }
+            throw new Error(`unexpected fetch ${u}`);
+        };
+
+        const out = await fetchPriceHistory('NPRO', 'USD');
+
+        deepEqual(out, { '2026-06-14': 0.30, '2026-06-15': 0.31 });
+        const cached = JSON.parse(await readFile(join(dataDir, 'prices', 'npro.json'), 'utf8'));
+        deepEqual(cached, { '2026-06-14': 0.30, '2026-06-15': 0.31 });
+    });
+
+    test('unknown token returns empty when neither source has it', async () => {
+        globalThis.fetch = async (url) => {
+            const u = url.toString();
+            if (u.includes('cryptocompare.com')) return jsonResponse({ Response: 'Error', Message: 'symbol not found' });
+            if (u.includes('coingecko.com')) return jsonResponse({ error: 'coin not found' });
+            throw new Error(`unexpected fetch ${u}`);
+        };
+        deepEqual(await fetchPriceHistory('TOTALLYUNKNOWNXYZ', 'USD'), {});
     });
 });

--- a/server/api/prices/getDailyPrice.js
+++ b/server/api/prices/getDailyPrice.js
@@ -1,6 +1,8 @@
 import { readForex, readTokenPrices, writeForex, writeTokenPrices } from './store.js';
 import { fetchFullDailyHistory } from './providers/cryptocompare.js';
+import { fetchDailyHistory as fetchCoinGeckoDailyHistory } from './providers/coingecko.js';
 import { fetchHistoryRange as fetchForexHistoryRange } from './providers/frankfurter.js';
+import { coinId } from './token-map.js';
 
 const tokenLoads = new Map();
 const forexLoads = new Map();
@@ -19,7 +21,24 @@ async function loadTokenPrices(symbol) {
     return once(tokenLoads, key, async () => {
         const cached = await readTokenPrices(key);
         if (cached && Object.keys(cached).length > 0) return cached;
-        const fresh = await fetchFullDailyHistory(key);
+
+        // CryptoCompare covers majors with long history; it throws for symbols it
+        // doesn't list. For those (NEAR-ecosystem tokens) fall back to CoinGecko
+        // market_chart by coin id (last 365 days). If neither has it, cache empty
+        // (no price) rather than erroring the whole report.
+        let fresh = {};
+        try {
+            fresh = await fetchFullDailyHistory(key);
+        } catch {
+            fresh = {};
+        }
+        if (Object.keys(fresh).length === 0) {
+            try {
+                fresh = await fetchCoinGeckoDailyHistory(coinId(key));
+            } catch {
+                fresh = {};
+            }
+        }
         await writeTokenPrices(key, fresh);
         return fresh;
     });

--- a/server/api/prices/index.js
+++ b/server/api/prices/index.js
@@ -1,7 +1,8 @@
-import { fetchSimplePrice } from './providers/coingecko.js';
+import { fetchSimplePrice, fetchDailyHistory as fetchCoinGeckoDailyHistory } from './providers/coingecko.js';
 import { fetchRecentDailyClose } from './providers/cryptocompare.js';
 import { fetchHistoryRange as fetchForexHistoryRange } from './providers/frankfurter.js';
 import { getPriceHistory } from './getDailyPrice.js';
+import { coinId, toSymbol } from './token-map.js';
 import {
     listCachedCurrencies,
     listCachedTokens,
@@ -11,92 +12,6 @@ import {
     writeTokenPrices
 } from './store.js';
 
-const COIN_IDS = {
-    '$wif': 'dogwifcoin',
-    aave: 'aave',
-    abg: 'ab-group',
-    ada: 'cardano',
-    adi: 'adi-token',
-    aleo: 'aleo',
-    apt: 'aptos',
-    arb: 'arbitrum',
-    aster: 'aster-2',
-    aurora: 'aurora-near',
-    avax: 'avalanche-2',
-    bch: 'bitcoin-cash',
-    bera: 'berachain-bera',
-    blackdragon: 'black-dragon',
-    bnb: 'binancecoin',
-    bome: 'book-of-meme',
-    brett: 'based-brett',
-    btc: 'bitcoin',
-    cbbtc: 'coinbase-wrapped-btc',
-    cfi: 'consumerfi-protocol',
-    cow: 'cow-protocol',
-    dai: 'dai',
-    dash: 'dash',
-    doge: 'dogecoin',
-    eth: 'ethereum',
-    eure: 'monerium-eur-money-2',
-    evaa: 'evaa-protocol',
-    frax: 'frax',
-    gbpe: 'monerium-gbp-emoney',
-    gmx: 'gmx',
-    gno: 'gnosis',
-    hapi: 'hapi',
-    itlx: 'intellex',
-    jambo: 'jambo-2',
-    kaito: 'kaito',
-    knc: 'kyber-network-crystal',
-    link: 'chainlink',
-    loud: 'loud',
-    ltc: 'litecoin',
-    melania: 'melania-meme',
-    mog: 'mog-coin',
-    mon: 'monad',
-    mpdao: 'meta-pool',
-    near: 'near',
-    npro: 'npro',
-    okb: 'okb',
-    op: 'optimism',
-    pengu: 'pudgy-penguins',
-    pepe: 'pepe',
-    pol: 'matic-network',
-    public: 'publicai',
-    rhea: 'rhea-2',
-    safe: 'safe',
-    shib: 'shiba-inu',
-    shitzu: 'shitzu',
-    sol: 'solana',
-    spx: 'spx6900',
-    stnear: 'staked-near',
-    strk: 'starknet',
-    sui: 'sui',
-    sweat: 'sweatcoin',
-    titn: 'thor-wallet',
-    ton: 'the-open-network',
-    trump: 'official-trump',
-    trx: 'tron',
-    turbo: 'turbo',
-    uni: 'uniswap',
-    usad: 'usad',
-    usd1: 'usd1-wlfi',
-    usdc: 'usd-coin',
-    usdcx: 'usdcx',
-    usdf: 'falcon-finance',
-    usdt: 'tether',
-    usdt0: 'usdt0',
-    wbtc: 'wrapped-bitcoin',
-    weth: 'weth',
-    wnear: 'wrapped-near',
-    xaut: 'tether-gold',
-    xbtc: 'xbtc-2',
-    xdai: 'xdai',
-    xlm: 'stellar',
-    xpl: 'plasma',
-    xrp: 'ripple',
-    zec: 'zcash'
-};
 
 const CURRENCYLIST_VS = [
     'aed', 'ars', 'aud', 'bch', 'bdt', 'bhd', 'bmd', 'bnb', 'brl', 'btc',
@@ -110,20 +25,6 @@ const CURRENCYLIST_VS = [
 
 const SPOT_TTL_MS = 60_000;
 const spotCache = new Map();
-
-const SYMBOL_BY_COIN_ID = Object.fromEntries(
-    Object.entries(COIN_IDS).map(([symbol, cgId]) => [cgId, symbol])
-);
-
-function coinId(token) {
-    const key = token.toLowerCase();
-    return COIN_IDS[key] ?? key;
-}
-
-function toSymbol(token) {
-    const key = token.toLowerCase();
-    return SYMBOL_BY_COIN_ID[key] ?? key;
-}
 
 async function spotCached(key, fetcher) {
     const entry = spotCache.get(key);
@@ -171,7 +72,13 @@ export async function runEodUpdate({ now = new Date() } = {}) {
             if (!data) continue;
             const lastDate = Object.keys(data).sort().at(-1);
             if (lastDate && lastDate >= yesterday) continue;
-            const fresh = await fetchRecentDailyClose(symbol, 7);
+            // CryptoCompare for majors; CoinGecko fallback for tokens it doesn't list.
+            let fresh;
+            try {
+                fresh = await fetchRecentDailyClose(symbol, 7);
+            } catch {
+                fresh = await fetchCoinGeckoDailyHistory(coinId(symbol), { days: 7 });
+            }
             let changed = false;
             for (const [date, price] of Object.entries(fresh)) {
                 if (data[date] == null) {

--- a/server/api/prices/providers/coingecko.js
+++ b/server/api/prices/providers/coingecko.js
@@ -8,3 +8,27 @@ export async function fetchSimplePrice(ids, vsCurrencies) {
     if (!res.ok) throw new Error(`CoinGecko ${res.status}`);
     return res.json();
 }
+
+/**
+ * Daily USD close history for a CoinGecko coin id via market_chart, as
+ * { 'YYYY-MM-DD': price }. History source for tokens CryptoCompare doesn't list
+ * (NEAR-ecosystem tokens like NPRO, stNEAR, SHITZU). The free tier caps `days`
+ * at 365, so older history isn't available this way.
+ */
+export async function fetchDailyHistory(id, { days = 365 } = {}) {
+    const url = new URL(`https://api.coingecko.com/api/v3/coins/${encodeURIComponent(id)}/market_chart`);
+    url.searchParams.set('vs_currency', 'usd');
+    url.searchParams.set('days', String(days));
+    url.searchParams.set('interval', 'daily');
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`CoinGecko market_chart ${res.status} for ${id}`);
+    const json = await res.json();
+    if (json.error || !Array.isArray(json.prices)) {
+        throw new Error(`CoinGecko market_chart for ${id}: ${JSON.stringify(json.error ?? json).slice(0, 120)}`);
+    }
+    const out = {};
+    for (const [ms, price] of json.prices) {
+        if (price > 0) out[new Date(ms).toISOString().slice(0, 10)] = price; // last point per day wins
+    }
+    return out;
+}

--- a/server/api/prices/token-map.js
+++ b/server/api/prices/token-map.js
@@ -1,0 +1,121 @@
+// Symbol/CoinGecko-id resolution shared by the spot and history price paths.
+
+const COIN_IDS = {
+    '$wif': 'dogwifcoin',
+    aave: 'aave',
+    abg: 'ab-group',
+    ada: 'cardano',
+    adi: 'adi-token',
+    aleo: 'aleo',
+    apt: 'aptos',
+    arb: 'arbitrum',
+    aster: 'aster-2',
+    aurora: 'aurora-near',
+    avax: 'avalanche-2',
+    bch: 'bitcoin-cash',
+    bera: 'berachain-bera',
+    blackdragon: 'black-dragon',
+    bnb: 'binancecoin',
+    bome: 'book-of-meme',
+    brett: 'based-brett',
+    btc: 'bitcoin',
+    cbbtc: 'coinbase-wrapped-btc',
+    cfi: 'consumerfi-protocol',
+    cow: 'cow-protocol',
+    dai: 'dai',
+    dash: 'dash',
+    doge: 'dogecoin',
+    eth: 'ethereum',
+    eure: 'monerium-eur-money-2',
+    evaa: 'evaa-protocol',
+    frax: 'frax',
+    gbpe: 'monerium-gbp-emoney',
+    gmx: 'gmx',
+    gno: 'gnosis',
+    hapi: 'hapi',
+    itlx: 'intellex',
+    jambo: 'jambo-2',
+    kaito: 'kaito',
+    knc: 'kyber-network-crystal',
+    link: 'chainlink',
+    loud: 'loud',
+    ltc: 'litecoin',
+    melania: 'melania-meme',
+    mog: 'mog-coin',
+    mon: 'monad',
+    mpdao: 'meta-pool',
+    near: 'near',
+    npro: 'npro',
+    okb: 'okb',
+    op: 'optimism',
+    pengu: 'pudgy-penguins',
+    pepe: 'pepe',
+    pol: 'matic-network',
+    public: 'publicai',
+    rhea: 'rhea-2',
+    safe: 'safe',
+    shib: 'shiba-inu',
+    shitzu: 'shitzu',
+    sol: 'solana',
+    spx: 'spx6900',
+    stnear: 'staked-near',
+    strk: 'starknet',
+    sui: 'sui',
+    sweat: 'sweatcoin',
+    titn: 'thor-wallet',
+    ton: 'the-open-network',
+    trump: 'official-trump',
+    trx: 'tron',
+    turbo: 'turbo',
+    uni: 'uniswap',
+    usad: 'usad',
+    usd1: 'usd1-wlfi',
+    usdc: 'usd-coin',
+    usdcx: 'usdcx',
+    usdf: 'falcon-finance',
+    usdt: 'tether',
+    usdt0: 'usdt0',
+    wbtc: 'wrapped-bitcoin',
+    weth: 'weth',
+    wnear: 'wrapped-near',
+    xaut: 'tether-gold',
+    xbtc: 'xbtc-2',
+    xdai: 'xdai',
+    xlm: 'stellar',
+    xpl: 'plasma',
+    xrp: 'ripple',
+    zec: 'zcash'
+};
+
+// Symbols that should be priced as another symbol (same/known-equivalent price).
+// - wNEAR (wrapped NEAR) tracks NEAR 1:1, and NEAR has long CryptoCompare history.
+// - Rainbow-bridged stablecoins (USDT.e / USDC.e) are priced as their canonical
+//   tokens.
+const SYMBOL_ALIASES = {
+    wnear: 'near',
+    'usdt.e': 'usdt',
+    'usdc.e': 'usdc'
+};
+
+const SYMBOL_BY_COIN_ID = Object.fromEntries(
+    Object.entries(COIN_IDS).map(([symbol, cgId]) => [cgId, symbol])
+);
+
+function normalize(token) {
+    const key = String(token).toLowerCase();
+    return SYMBOL_ALIASES[key] ?? key;
+}
+
+/** Resolve a token (ticker or CoinGecko id) to its CoinGecko id. */
+export function coinId(token) {
+    const key = normalize(token);
+    return COIN_IDS[key] ?? key;
+}
+
+/** Resolve a token (ticker or CoinGecko id) to its ticker symbol. */
+export function toSymbol(token) {
+    const key = normalize(token);
+    return SYMBOL_BY_COIN_ID[key] ?? key;
+}
+
+export { COIN_IDS };


### PR DESCRIPTION
## Summary

Price **history** previously came only from CryptoCompare (which lists majors), so NEAR-ecosystem tokens (NPRO, stNEAR, SHITZU, wNEAR, bridged stablecoins) had no history — the year report errored / showed the "missing price" prompt for them.

- **`token-map.js`** (extracted from `index.js`): adds `SYMBOL_ALIASES` — `wnear→near` (wNEAR tracks NEAR 1:1; NEAR has long CryptoCompare history), and `usdt.e→usdt` / `usdc.e→usdc` (Rainbow-bridged stablecoins).
- **CoinGecko historical fallback** (`providers/coingecko.js` `fetchDailyHistory` via `market_chart`): used in `getDailyPrice.loadTokenPrices` and the EOD updater when CryptoCompare doesn't list a symbol — keyed by the existing coin-id map (`npro`, `staked-near`, `shitzu`, …). Free tier covers the last 365 days.
- Unknown / scam tokens now resolve to **empty** history (graceful) instead of surfacing a 500.

## Verified live (real APIs)
wNEAR (→NEAR), USDT.e, stNEAR, NPRO, SHITZU all return daily history.

## Tests
12 prices tests (incl. alias, CoinGecko fallback, empty-when-unknown) + 38 gateway unit total. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)