### PR TITLE
Bump near-accounting-export: FT-claim gap self-heal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#4278df75e4156b8c9b82abbb777fd4e4fafb879c",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1393,8 +1393,8 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#4278df75e4156b8c9b82abbb777fd4e4fafb879c",
-      "integrity": "sha512-vtyw3O1jGVCAXjjc0iNZaOzhMXC2eLci3B1YVgmxwztIei9Nu69LThIn6LwSa6QCx4scLNDCygN+pAJGpU8NgQ==",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
+      "integrity": "sha512-TPGmvmdYSAG/w/vnGE1JjaYicq/Xm016hqQTZNLj2jUjaJbNhULExR1Be6J623I/7yVa+KsO1r7OJLB7IFD5jQ==",
       "license": "ISC",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#4278df75e4156b8c9b82abbb777fd4e4fafb879c",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `near-accounting-export` to `df2bf01` (PR petersalomonsen/near-accounting-export#60).

Brings in:
- `fillOwnedGapsFromApi` — repairs dropped FT claims / intents deposits by re-fetching the gapped token's full ledger from the transfers API (recovered credit lands on the same tx that previously showed only NEAR gas).
- `historyComplete` gated on FT token gaps, so accounts with genuinely-missing token data are re-visited until the API indexes the credit.

Effect: `petersalomonsen.near`'s 9 NPRO gaps (~237 NPRO of daily distribution claims) self-repair on the next sync cycle. No data migration / version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)