### PR TITLE
prices: expose no-price tokens so clients skip unpriceable tokens

### DIFF
--- a/server/api/prices.test.js
+++ b/server/api/prices.test.js
@@ -7,6 +7,7 @@ import { deepEqual, equal, ok, rejects } from 'node:assert/strict';
 import {
     fetchCurrencyList,
     fetchCurrent,
+    fetchNoPriceTokens,
     fetchPriceHistory,
     runEodUpdate
 } from './prices/index.js';
@@ -253,5 +254,18 @@ describe('prices', () => {
             throw new Error(`unexpected fetch ${u}`);
         };
         deepEqual(await fetchPriceHistory('TOTALLYUNKNOWNXYZ', 'USD'), {});
+    });
+
+    test('nopricetokens lists cached tokens with an empty price map (the no-price set)', async () => {
+        await mkdir(join(dataDir, 'prices'), { recursive: true });
+        // A token with prices, and two with none (scam token + ARIZ credits).
+        await writeFile(join(dataDir, 'prices', 'near.json'), JSON.stringify({ '2024-06-22': 5.0 }));
+        await writeFile(join(dataDir, 'prices', 'scamtoken.json'), JSON.stringify({}));
+        await writeFile(join(dataDir, 'prices', 'ariz.json'), JSON.stringify({}));
+        globalThis.fetch = async (url) => { throw new Error(`unexpected fetch ${url}`); };
+
+        const noPrice = await fetchNoPriceTokens();
+
+        deepEqual([...noPrice].sort(), ['ariz', 'scamtoken']);
     });
 });

--- a/server/api/prices/index.js
+++ b/server/api/prices/index.js
@@ -47,6 +47,25 @@ export async function fetchPriceHistory(baseToken = 'NEAR', currency = 'USD', to
     return getPriceHistory(toSymbol(baseToken), currency, todate);
 }
 
+// Tokens we've fetched for but found no price anywhere (CryptoCompare + CoinGecko
+// both empty) - e.g. scam tokens and ARIZ credits. Derived live from the cache so
+// it self-heals: the EOD updater keeps re-checking empty entries, and a token that
+// later lists drops off this set automatically. Returned as the lowercase cache
+// keys, which match the CoinGecko id the client sends for unlisted tokens.
+export async function fetchNoPriceTokens() {
+    return spotCached('nopricetokens', async () => {
+        const tokens = await listCachedTokens();
+        const noPrice = [];
+        for (const symbol of tokens) {
+            const data = await readTokenPrices(symbol);
+            if (!data || Object.keys(data).length === 0) {
+                noPrice.push(symbol);
+            }
+        }
+        return noPrice;
+    });
+}
+
 export async function fetchCurrent(tokens, vsCurrencies) {
     if (!tokens || tokens.length === 0) return {};
     const vs = vsCurrencies && vsCurrencies.length > 0 ? vsCurrencies : ['usd'];

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import {
     fetchCurrencyList,
     fetchCurrent,
+    fetchNoPriceTokens,
     fetchPriceHistory,
     startEodScheduler
 } from './api/prices/index.js';
@@ -69,6 +70,11 @@ app.get('/api/prices/history', auth, async (req, res) => {
         null,
         1
     ));
+});
+
+app.get('/api/prices/nopricetokens', auth, async (req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(await fetchNoPriceTokens(), null, 1));
 });
 
 app.get('/api/prices/current', auth, async (req, res) => {


### PR DESCRIPTION
## What

Adds `GET /api/prices/nopricetokens`, returning the set of tokens the gateway has
found no price for (neither CryptoCompare nor CoinGecko list them) — e.g. scam
tokens and ARIZ credits.

## Why

The frontend prompts "price missing locally, fetch?" per date when building
reports. For tokens with no price the gateway returns an empty `{}`, so every
date re-triggered a whole-history fetch — many repeated requests when updating a
currency (e.g. NOK). Rather than have **every user** maintain their own ignore
list, the gateway — which already fetches the data — is the natural authority on
which tokens have no price.

## How

`fetchNoPriceTokens()` derives the set **live** from the price cache (tokens whose
cached map is empty), so it self-heals: the EOD updater keeps re-checking empty
entries, and a token that later lists drops off the set automatically. No frozen
blocklist. Returned as the lowercase cache keys, which match the CoinGecko id the
client sends for unlisted tokens.

The frontend change that consumes this endpoint is in the Ariz-Portfolio repo.

## Test

`fetchNoPriceTokens` unit test added; full suite green (39 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)