### PR TITLE
gateway: git smart-HTTP server (a wasm-git remote per paying account)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
+        "cgi": "^0.3.1",
         "express": "^4.21.2",
         "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
         "near-api-js": "^2.1.4"
@@ -445,6 +446,23 @@
         "base-x": "^3.0.2"
       }
     },
+    "node_modules/bufferjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
+      "integrity": "sha512-qrCIGPcd9ODawCNyqR2o55zgaC/r7XHZ7oUh2s99uk+NVBS3SjIHigxS1S2KXpt8wsoQxAN55iPi8GIH8TGMRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/bufferlist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bufferlist/-/bufferlist-0.1.0.tgz",
+      "integrity": "sha512-cg77q4YhmxV+/e7WhrShHGyOgey0GowZwg0cfXKCz5v3wfx73pUyrsnLnGY7DQZnjhtvmAaSMrf045zuJpDGDg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -530,6 +548,18 @@
       "resolved": "https://registry.npmjs.org/capability/-/capability-0.2.5.tgz",
       "integrity": "sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg==",
       "license": "MIT"
+    },
+    "node_modules/cgi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cgi/-/cgi-0.3.1.tgz",
+      "integrity": "sha512-V8UI9xBCOBKkuw1UEnD5NxHNuYDGCN3q4FncqNXPDpsSEQWwBShqUrvxIf+nL31hMHc5RCbkAuUy4r7j0wx00A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2",
+        "extend": "~2.0.0",
+        "header-stack": "~0.0.2",
+        "stream-stack": "~1.1.1"
+      }
     },
     "node_modules/chownr": {
       "version": "2.0.0",
@@ -834,6 +864,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+      "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1091,6 +1127,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/header-stack": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/header-stack/-/header-stack-0.0.2.tgz",
+      "integrity": "sha512-/Qs4VDHOv6/d7V59PxaNJvXUnk9er47KViQLa1l03dxvSzStHuAIN6cHMY1hHH/o+ceROmzaDLje918QKty0Jw==",
+      "dependencies": {
+        "bufferjs": ">= 0.2.3",
+        "bufferlist": ">= 0.0.6",
+        "stream-stack": ">= 1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -2005,6 +2054,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-stack": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/stream-stack/-/stream-stack-1.1.4.tgz",
+      "integrity": "sha512-bmRYXVkxuyuiK3kvf54hgfLpv2TGlNzXE9S/DCPV82HqhcDonPFuRBWpeQUCpnRrprVCqXwrxVTq9WDwrrsLTg==",
+      "engines": {
+        "node": ">= 0.3.0"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "license": "MIT",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node --test server/accesscontrol/*.test.js server/api/*.test.js server/arizcredits/*.test.js",
+    "test": "node --test server/git.test.js server/accesscontrol/*.test.js server/api/*.test.js server/arizcredits/*.test.js",
     "build:contract": "cd contract && cargo build --target=wasm32-unknown-unknown --release && wasm-opt --signext-lowering -Oz target/wasm32-unknown-unknown/release/ariz_gateway.wasm -o target/wasm32-unknown-unknown/release/ariz_gateway.wasm",
     "pretest:integration": "npm run build:contract",
     "test:integration": "node --test server/index.test.js",
     "test:arizcredits-upgrade": "node --test arizcredits/sandbox/upgrade.test.js"
   },
   "dependencies": {
+    "cgi": "^0.3.1",
     "express": "^4.21.2",
     "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
     "near-api-js": "^2.1.4"

--- a/server/git.js
+++ b/server/git.js
@@ -1,0 +1,63 @@
+import cgi from 'cgi';
+import { existsSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+// Restrict a URL path segment (account id / repo name) to a safe directory name,
+// so it can never traverse out of the per-account git root.
+function safeSegment(seg) {
+    const cleaned = String(seg).replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^\.+/, '_');
+    return cleaned || '_';
+}
+
+/**
+ * Git smart-HTTP handler. Serves one bare repo per authenticated account under
+ * `<dataDir>/git/<account>/<repo>.git` via `git http-backend`. The account comes
+ * from the auth middleware (`req.accountId`), so a caller only ever reaches their
+ * own repos; the repo name comes from the URL. Bare repos are created lazily on
+ * first access (push-enabled), so a client can clone an empty repo and push to it.
+ *
+ * Mount behind auth:  app.use('/git', auth, createGitHandler({ dataDir }))
+ * Client remote URL:  <gateway>/git/<repo>   (the account is implied by the token)
+ */
+export function createGitHandler({ dataDir }) {
+    const gitRoot = join(dataDir, 'git');
+
+    return function gitHandler(req, res) {
+        const account = req.accountId;
+        if (!account) { res.statusCode = 401; res.end('unauthorized'); return; }
+
+        // After the /git mount, req.url is /<repo>[.git]/<service>[?query], e.g.
+        // /nearsight/info/refs?service=git-upload-pack  or  /nearsight/git-receive-pack
+        const url = req.url || '/';
+        const firstSlash = url.indexOf('/', 1);
+        const firstSeg = (firstSlash === -1 ? url.slice(1) : url.slice(1, firstSlash)).split('?')[0];
+        const rest = firstSlash === -1 ? '' : url.slice(firstSlash);
+        const repoName = safeSegment(firstSeg.replace(/\.git$/, ''));
+        if (firstSeg === '') { res.statusCode = 404; res.end('repo not specified'); return; }
+
+        const accountDir = join(gitRoot, safeSegment(account));
+        const repoDir = `${repoName}.git`;
+        const repoPath = join(accountDir, repoDir);
+        if (!existsSync(repoPath)) {
+            mkdirSync(accountDir, { recursive: true });
+            execFileSync('git', ['init', '--bare', '--initial-branch=master', repoPath]);
+            // Allow authenticated push over HTTP to this repo.
+            execFileSync('git', ['-C', repoPath, 'config', 'http.receivepack', 'true']);
+        }
+
+        // http-backend resolves GIT_PROJECT_ROOT + PATH_INFO, so PATH_INFO must
+        // name the on-disk dir (<repo>.git) regardless of how the client spelled it.
+        req.url = `/${repoDir}${rest}`;
+        const handler = cgi('git', {
+            args: ['http-backend'],
+            stderr: process.stderr,
+            env: {
+                GIT_PROJECT_ROOT: accountDir,
+                GIT_HTTP_EXPORT_ALL: '1',
+                REMOTE_USER: account, // marks the request authenticated (enables receive-pack)
+            },
+        });
+        handler(req, res);
+    };
+}

--- a/server/git.test.js
+++ b/server/git.test.js
@@ -1,0 +1,80 @@
+import { test, before, after, describe } from 'node:test';
+import { ok, equal } from 'node:assert/strict';
+import express from 'express';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createGitHandler } from './git.js';
+
+const pexec = promisify(execFile);
+
+// Run a git command (async, so the in-process server stays responsive — a sync
+// child would block the event loop and deadlock against its own HTTP server).
+// A fixed identity + no prompts keeps it hermetic.
+async function git(args, cwd) {
+    const { stdout } = await pexec('git', args, {
+        cwd,
+        env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: 'Test', GIT_AUTHOR_EMAIL: 't@example.com',
+            GIT_COMMITTER_NAME: 'Test', GIT_COMMITTER_EMAIL: 't@example.com',
+            GIT_TERMINAL_PROMPT: '0',
+        },
+    });
+    return stdout;
+}
+
+describe('gateway git server', () => {
+    let dataDir, work, server, base;
+
+    before(async () => {
+        dataDir = mkdtempSync(join(tmpdir(), 'git-srv-'));
+        work = mkdtempSync(join(tmpdir(), 'git-work-'));
+        const app = express();
+        // Stub the auth middleware: the account comes from a header so we can
+        // exercise per-account isolation. In production this is req.accountId set
+        // by the NEP-413 auth middleware.
+        app.use('/git', (req, res, next) => {
+            req.accountId = req.headers['x-test-account'] || 'alice.near';
+            next();
+        }, createGitHandler({ dataDir }));
+        await new Promise((r) => { server = app.listen(0, r); });
+        base = `http://localhost:${server.address().port}/git`;
+    });
+
+    after(() => {
+        server?.close();
+        rmSync(dataDir, { recursive: true, force: true });
+        rmSync(work, { recursive: true, force: true });
+    });
+
+    test('clone (lazy-init) -> commit -> push -> re-clone sees the data', async () => {
+        const a = join(work, 'a');
+        await git(['clone', `${base}/nearsight`, a]); // lazily creates an empty bare repo
+        writeFileSync(join(a, 'hello.txt'), 'hello from the gateway git server');
+        await git(['add', 'hello.txt'], a);
+        await git(['commit', '-m', 'first'], a);
+        await git(['push', 'origin', 'HEAD:master'], a);
+
+        const b = join(work, 'b');
+        await git(['clone', `${base}/nearsight`, b]);
+        equal(readFileSync(join(b, 'hello.txt'), 'utf8'), 'hello from the gateway git server');
+    });
+
+    test('repos are isolated per authenticated account', async () => {
+        // bob clones the same repo *name* — but it resolves under bob's own dir,
+        // so it is a different (empty) repo and must not see alice's file.
+        const c = join(work, 'c');
+        await git(['-c', 'http.extraHeader=X-Test-Account: bob.near', 'clone', `${base}/nearsight`, c]);
+        ok(!existsSync(join(c, 'hello.txt')), "bob must not see alice's repo");
+    });
+
+    test('refuses when no account is present (defensive)', () => {
+        const handler = createGitHandler({ dataDir });
+        const res = { statusCode: 200, body: null, end(b) { this.body = b; } };
+        handler({ url: '/nearsight/info/refs', accountId: undefined }, res);
+        equal(res.statusCode, 401);
+    });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ import {
 } from './api/prices/index.js';
 import { createAuthMiddleware } from './accesscontrol/middleware.js';
 import { createRpcHandler } from './rpc.js';
+import { createGitHandler } from './git.js';
 import { createRouter as createAccountingRouter, startWorker as startAccountingWorker } from 'near-accounting-export';
 import { createDeductClient } from './arizcredits/deduct.js';
 import { createBillingPass } from './arizcredits/billing.js';
@@ -73,6 +74,7 @@ app.use((req, res, next) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     if (req.method === 'OPTIONS') {
         res.setHeader('Access-Control-Allow-Headers', '*');
+        res.setHeader('Access-Control-Allow-Methods', '*');
         res.end();
         return;
     }
@@ -146,6 +148,27 @@ app.use('/api/accounting/:accountId', auth, async (req, res, next) => {
     dataDir
 }));
 
+// Git smart-HTTP: a bare repo per authenticated account under <dataDir>/git,
+// for storing the user's portfolio data repo on the gateway (the wasm-git remote).
+// When billing is on, it's gated on the same authorised + funded check as
+// accounting (a paying-user feature). Mounted before the frontend so the SPA
+// fallback never swallows /git requests.
+const gitHandler = createGitHandler({ dataDir });
+app.use('/git', auth, async (req, res, next) => {
+    if (accountGate) {
+        let authorized = false;
+        try { authorized = await accountGate(req.accountId); } catch { authorized = false; } // fail closed
+        if (!authorized) {
+            return res.status(402).json({
+                error: 'authorization_required',
+                accountId: req.accountId,
+                message: 'A git repository on the gateway requires an account that has authorized the gateway (authorize_deduction on arizcredits.near) and holds ARIZ.',
+            });
+        }
+    }
+    gitHandler(req, res);
+});
+
 if (frontendEnabled) {
     // Static assets first, then an SPA fallback to index.html for client-routed
     // paths (/accounts, /staking, ...). API routes are registered above, so they
@@ -156,7 +179,7 @@ if (frontendEnabled) {
     });
     app.use(express.static(frontendDir, { index: false }));
     app.use((req, res, next) => {
-        if (req.method !== 'GET' || req.path.startsWith('/api') || req.path.startsWith('/rpc')) {
+        if (req.method !== 'GET' || req.path.startsWith('/api') || req.path.startsWith('/rpc') || req.path.startsWith('/git')) {
             return next();
         }
         setIsolationHeaders(res);


### PR DESCRIPTION
## What

Adds a git smart-HTTP server to the gateway: `GET/POST /git/<repo>` backed by
`git http-backend`, serving one bare repo **per authenticated account** under
`<dataDir>/git/<account>/<repo>.git`. This is the durable remote for the wasm-git
portfolio repo — so a user's only-in-browser data can be pushed somewhere safe.

## Why

The portfolio app stores its data in an in-browser git repo (wasm-git). Until now
there was no remote to push it to — the data lived only in the browser. The gateway
already has the right primitives (NEP-413 auth, the paying-account gate, a
persistent `/data` volume, and `git` in the image), so the remote belongs here.

## How

- `server/git.js` — `createGitHandler({ dataDir })`. Account from `req.accountId`
  (so callers only ever reach their own repos); repo name from the URL. Bare repos
  are **lazily created, push-enabled** (`http.receivepack=true`), so a client can
  clone an empty repo and push the first commit — the first-backup flow.
- Mounted `app.use('/git', auth, …)`; when billing is on, also gated on the same
  authorised + funded check as accounting (paying-user feature). Mounted **before**
  the frontend so the SPA fallback can't swallow `/git`.
- CORS: preflight now also returns `Access-Control-Allow-Methods: *` — the wasm-git
  client sends an `Authorization` header on `info/refs`, which preflights even the GET.

## Client usage

Remote URL: `https://arizgateway.fly.dev/git/<repo-name>` (account implied by the
NEP-413 token). The Storage page sets this as the remote and Synchronize pushes.

## Test

`server/git.test.js` (wired into `npm test`): clone → commit → **push** → re-clone
round-trip, per-account isolation (bob can't see alice's repo), and the no-account
guard. Full suite: 42/42. Boot-checked: unauthenticated `/git` → 401, preflight →
`Allow-Methods: *`.

Note: the `git` driver in the test is async on purpose — a sync child process would
block the event loop and deadlock against the in-process HTTP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)