### PR TITLE
Fix gateway crash on path-unsafe token symbols; start HTTP server before workers

### DIFF
--- a/server/api/prices/store.js
+++ b/server/api/prices/store.js
@@ -29,11 +29,30 @@ async function writeJsonAtomic(path, dir, data) {
     await rename(tmp, path);
 }
 
+// Token symbols are not safe to use directly as file names: scam tokens can embed
+// a whole URL or sentence in their symbol (e.g. "Claim Near Airdrop at
+// https://..."), and the "/" then makes join() treat it as a path into a
+// non-existent directory, so the write throws ENOENT and crashes the process.
+// encodeURIComponent strips path separators while leaving normal symbols
+// (near, usd-coin) unchanged, so it's safe and backward-compatible with existing
+// cache files. Pair it with decodeKey on the way out so listed names round-trip.
+function fileKey(name) {
+    return encodeURIComponent(name.toLowerCase());
+}
+
+function decodeKey(name) {
+    try {
+        return decodeURIComponent(name);
+    } catch {
+        return name;
+    }
+}
+
 async function listJsonFiles(dir) {
     try {
         return (await readdir(dir))
             .filter(f => f.endsWith('.json'))
-            .map(f => f.slice(0, -'.json'.length));
+            .map(f => decodeKey(f.slice(0, -'.json'.length)));
     } catch (err) {
         if (err.code === 'ENOENT') return [];
         throw err;
@@ -41,12 +60,12 @@ async function listJsonFiles(dir) {
 }
 
 export async function readTokenPrices(symbol) {
-    return readJson(join(pricesDir(), `${symbol.toLowerCase()}.json`));
+    return readJson(join(pricesDir(), `${fileKey(symbol)}.json`));
 }
 
 export async function writeTokenPrices(symbol, data) {
     const dir = pricesDir();
-    await writeJsonAtomic(join(dir, `${symbol.toLowerCase()}.json`), dir, data);
+    await writeJsonAtomic(join(dir, `${fileKey(symbol)}.json`), dir, data);
 }
 
 export async function readForex(currency) {

--- a/server/index.js
+++ b/server/index.js
@@ -202,11 +202,27 @@ app.use((err, req, res, _next) => {
     }
 });
 
-startEodScheduler();
+// Start listening immediately, before any background job. A failing worker must
+// not be able to prevent the gateway from binding its port or crash-loop the
+// process - the HTTP API (including the price endpoints) has to stay up
+// independently of the background workers.
+const server = app.listen(SERVER_PORT, () => {
+    console.log('server listening at port', SERVER_PORT);
+});
+
+try {
+    startEodScheduler();
+} catch (e) {
+    console.error('Failed to start EOD price scheduler; gateway continues:', e);
+}
 
 let accountingWorker = null;
 if (process.env.ARIZ_GATEWAY_DISABLE_ACCOUNTING_WORKER !== 'true') {
-    accountingWorker = await startAccountingWorker({ dataDir });
+    try {
+        accountingWorker = await startAccountingWorker({ dataDir });
+    } catch (e) {
+        console.error('Failed to start accounting worker; gateway continues without it:', e);
+    }
 }
 
 // Enrollment reconciliation: periodically prune accounts that no longer qualify
@@ -274,10 +290,6 @@ if (billingEnabled) {
 } else {
     console.log('ARIZ usage billing disabled (set ARIZCREDITS_OPERATOR_KEY + ARIZ_PER_FASTNEAR_REQUEST to enable)');
 }
-
-const server = app.listen(SERVER_PORT, () => {
-    console.log('server listening at port', SERVER_PORT);
-});
 
 async function shutdown() {
     server.close();


### PR DESCRIPTION
## What
Two stability fixes that together stop the gateway from crash-looping on fly.

### 1. Crash on path-unsafe token symbols (the actual crash)
`store.js` used the token symbol directly as a cache filename. A scam token whose symbol embeds a URL ("Claim Near Airdrop at https://...") contains `/`, so `join()` treated it as a path into a non-existent directory and the write threw ENOENT — an unhandled rejection that killed the process. Any `/api/prices/history` request for such a token crashed the gateway, which produced the fly crash-loop (machines restarting, "not listening on port 8080", repeated 502s).

Fix: sanitize the symbol into a safe filename with `encodeURIComponent` (normal symbols like `near`/`usd-coin` are unchanged, so it's backward-compatible with existing cache files), and decode on the way back out.

### 2. Startup order (defense in depth)
`app.listen()` ran *after* `await startAccountingWorker(...)`, so a worker failure prevented the process from binding its port and crash-looped it. The HTTP server now starts first, and the EOD scheduler + accounting worker startup are wrapped in try/catch, so a background-job failure is logged but never takes down the API.

## Testing
- Reproduced locally: a `/api/prices/history` request for the scam token crashed the old build; with the fix the gateway stays up and the file is written safely.
- Repo CI runs the unit + integration suite on this PR.