### PR TITLE
Mount the encrypted object store at /store (encrypted-git-storage v0.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install ariz-gateway deps
         working-directory: ariz-gateway

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 WORKDIR /app
 
 RUN apt-get update \

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,323 @@
     "": {
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1085.0",
         "cgi": "^0.3.1",
+        "encrypted-git-storage": "github:petersalomonsen/encrypted-git-storage#v0.1.1",
         "express": "^4.21.2",
         "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
         "near-workspaces": "^3.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+      "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+      "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.16",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+      "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@near-js/accounts": {
@@ -223,6 +533,87 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -425,6 +816,12 @@
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -750,6 +1147,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encrypted-git-storage": {
+      "version": "0.1.1",
+      "resolved": "git+ssh://git@github.com/petersalomonsen/encrypted-git-storage.git#0ada95780c201b97911a968561fcbb94c1ba8b86",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.658.0",
+        "express": "^4.21.2"
+      },
+      "bin": {
+        "git-remote-egit": "src/remote-helper/git-remote-egit.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/end-of-stream": {
@@ -2112,6 +2524,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
   "license": "MIT",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node --test server/git.test.js server/accesscontrol/*.test.js server/api/*.test.js server/arizcredits/*.test.js",
+    "test": "node --test server/git.test.js server/store.test.js server/accesscontrol/*.test.js server/api/*.test.js server/arizcredits/*.test.js",
     "build:contract": "cd contract && cargo build --target=wasm32-unknown-unknown --release && wasm-opt --signext-lowering -Oz target/wasm32-unknown-unknown/release/ariz_gateway.wasm -o target/wasm32-unknown-unknown/release/ariz_gateway.wasm",
     "pretest:integration": "npm run build:contract",
     "test:integration": "node --test server/index.test.js",
     "test:arizcredits-upgrade": "node --test arizcredits/sandbox/upgrade.test.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1085.0",
     "cgi": "^0.3.1",
+    "encrypted-git-storage": "github:petersalomonsen/encrypted-git-storage#v0.1.1",
     "express": "^4.21.2",
     "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
     "near-api-js": "^2.1.4"

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,8 @@ import {
 import { createAuthMiddleware } from './accesscontrol/middleware.js';
 import { createRpcHandler } from './rpc.js';
 import { createGitHandler } from './git.js';
+import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+import { S3Client } from '@aws-sdk/client-s3';
 import { createRouter as createAccountingRouter, startWorker as startAccountingWorker } from 'near-accounting-export';
 import { createDeductClient } from './arizcredits/deduct.js';
 import { createBillingPass } from './arizcredits/billing.js';
@@ -168,6 +170,61 @@ app.use('/git', auth, async (req, res, next) => {
     }
     gitHandler(req, res);
 });
+
+// Encrypted object store (encrypted-git-storage): whole-repo client-side
+// encrypted git packfiles in S3-compatible object storage — the gateway only
+// ever sees ciphertext. It authenticates the caller (NEP-413) and scopes them to
+// their own `<account>/*` keys (repoId = the authenticated account). Configured
+// via Tigris' AWS_* env (`fly storage create`) or S3_* (dev/MinIO); disabled
+// when no bucket is configured. CORS is required because the app page lives on
+// arizportfolio.near.page while pushes are PUTs, which web4 can't proxy — the
+// service worker calls this origin directly (preflighted PUTs included).
+// See arizas/Ariz-Portfolio#76.
+const storeBucket = process.env.BUCKET_NAME ?? process.env.S3_BUCKET;
+const storeEndpoint = process.env.AWS_ENDPOINT_URL_S3 ?? process.env.S3_ENDPOINT;
+if (storeBucket && storeEndpoint) {
+    const storeS3 = new S3Client({
+        endpoint: storeEndpoint,
+        region: process.env.AWS_REGION ?? process.env.S3_REGION ?? 'auto',
+        // Path-style for dev/MinIO (S3_ENDPOINT); Tigris/AWS use virtual-host style.
+        forcePathStyle: !!process.env.S3_ENDPOINT,
+        // With Tigris the AWS_* credentials come from the default provider chain.
+        ...(process.env.S3_ACCESS_KEY ? {
+            credentials: {
+                accessKeyId: process.env.S3_ACCESS_KEY,
+                secretAccessKey: process.env.S3_SECRET_KEY,
+            },
+        } : {}),
+    });
+    const storeProxy = createStoreProxy({
+        s3: storeS3,
+        bucket: storeBucket,
+        allowedOrigins: splitList(process.env.ARIZ_STORE_ALLOWED_ORIGINS ?? 'https://arizportfolio.near.page'),
+        auth: (req) => req.accountId ?? null,
+    });
+    app.use('/store', (req, res, next) => {
+        // CORS preflights carry no Authorization header by spec — the proxy
+        // answers them; everything else authenticates (and is billing-gated) first.
+        if (req.method === 'OPTIONS') return storeProxy(req, res, next);
+        auth(req, res, async () => {
+            if (accountGate) {
+                let authorized = false;
+                try { authorized = await accountGate(req.accountId); } catch { authorized = false; } // fail closed
+                if (!authorized) {
+                    return res.status(402).json({
+                        error: 'authorization_required',
+                        accountId: req.accountId,
+                        message: 'The encrypted store requires an account that has authorized the gateway (authorize_deduction on arizcredits.near) and holds ARIZ.',
+                    });
+                }
+            }
+            storeProxy(req, res, next);
+        });
+    });
+    console.log(`encrypted store: /store -> ${storeEndpoint} bucket=${storeBucket}`);
+} else {
+    console.log('encrypted store: disabled (set BUCKET_NAME + AWS_ENDPOINT_URL_S3, or S3_BUCKET + S3_ENDPOINT)');
+}
 
 if (frontendEnabled) {
     // Static assets first, then an SPA fallback to index.html for client-routed

--- a/server/store.test.js
+++ b/server/store.test.js
@@ -1,0 +1,126 @@
+import { test, before, after, describe } from 'node:test';
+import { equal, deepEqual, ok } from 'node:assert/strict';
+import express from 'express';
+import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+
+// Wiring tests for the /store mount (encrypted-git-storage): NEP-413-style auth
+// scoping (repoId = authenticated account), the unauthenticated CORS preflight
+// bypass, and a refs round-trip — against an in-memory fake S3, so no MinIO is
+// needed in this repo's CI (the library's own CI covers the real S3 semantics).
+function fakeS3() {
+    const objects = new Map(); // key -> { body: Buffer, etag: string }
+    let etagCounter = 0;
+    return {
+        objects,
+        async send(cmd) {
+            const { Key, Body, IfMatch, IfNoneMatch, Prefix } = cmd.input;
+            switch (cmd.constructor.name) {
+                case 'PutObjectCommand': {
+                    const existing = objects.get(Key);
+                    if (IfNoneMatch === '*' && existing) throw Object.assign(new Error('exists'), { name: 'PreconditionFailed' });
+                    if (IfMatch && (!existing || existing.etag !== IfMatch)) throw Object.assign(new Error('mismatch'), { name: 'PreconditionFailed' });
+                    const etag = `"e${++etagCounter}"`;
+                    objects.set(Key, { body: Buffer.from(Body), etag });
+                    return { ETag: etag };
+                }
+                case 'GetObjectCommand': {
+                    const o = objects.get(Key);
+                    if (!o) throw Object.assign(new Error('missing'), { name: 'NoSuchKey' });
+                    return { ETag: o.etag, Body: { transformToByteArray: async () => new Uint8Array(o.body) } };
+                }
+                case 'ListObjectsV2Command':
+                    return {
+                        Contents: [...objects.entries()]
+                            .filter(([k]) => k.startsWith(Prefix))
+                            .map(([k, v]) => ({ Key: k, Size: v.body.length, LastModified: new Date() })),
+                    };
+                case 'DeleteObjectCommand':
+                    objects.delete(Key);
+                    return {};
+                default:
+                    throw new Error(`fake s3: unhandled ${cmd.constructor.name}`);
+            }
+        },
+    };
+}
+
+const ORIGIN = 'https://arizportfolio.near.page';
+
+describe('encrypted store mount (/store)', () => {
+    let server, base, s3;
+
+    before(async () => {
+        s3 = fakeS3();
+        const storeProxy = createStoreProxy({
+            s3,
+            bucket: 'test',
+            allowedOrigins: [ORIGIN],
+            auth: (req) => req.accountId ?? null,
+        });
+        const app = express();
+        // Same composition as server/index.js: OPTIONS bypasses auth (a CORS
+        // preflight carries no Authorization header); everything else must
+        // authenticate. Auth is stubbed like git.test.js: account from a header.
+        app.use('/store', (req, res, next) => {
+            if (req.method === 'OPTIONS') return storeProxy(req, res, next);
+            const account = req.headers['x-test-account'];
+            if (!account) return res.status(401).send('failed to parse token');
+            req.accountId = account;
+            storeProxy(req, res, next);
+        });
+        await new Promise((r) => { server = app.listen(0, r); });
+        base = `http://localhost:${server.address().port}/store`;
+    });
+
+    after(() => server?.close());
+
+    const asAlice = { 'x-test-account': 'alice.near' };
+
+    test('CORS preflight is answered without authentication', async () => {
+        const res = await fetch(`${base}/alice.near/refs`, {
+            method: 'OPTIONS',
+            headers: {
+                Origin: ORIGIN,
+                'Access-Control-Request-Method': 'PUT',
+                'Access-Control-Request-Headers': 'authorization,content-type,if-match',
+            },
+        });
+        equal(res.status, 204);
+        equal(res.headers.get('access-control-allow-origin'), ORIGIN);
+        ok(res.headers.get('access-control-allow-methods').includes('PUT'));
+        ok(res.headers.get('access-control-expose-headers').includes('ETag'));
+    });
+
+    test('unauthenticated requests are rejected', async () => {
+        equal((await fetch(`${base}/alice.near/refs`)).status, 401);
+    });
+
+    test('an account only reaches its own store (repoId = account)', async () => {
+        equal((await fetch(`${base}/bob.near/refs`, { headers: asAlice })).status, 403);
+    });
+
+    test('refs round-trip: create (If-None-Match) then read back', async () => {
+        const put = await fetch(`${base}/alice.near/refs`, {
+            method: 'PUT',
+            headers: { ...asAlice, 'if-none-match': '*', 'content-type': 'application/octet-stream' },
+            body: Buffer.from('ciphertext-refs-v1'),
+        });
+        equal(put.status, 204);
+
+        const get = await fetch(`${base}/alice.near/refs`, { headers: asAlice });
+        equal(get.status, 200);
+        equal(Buffer.from(await get.arrayBuffer()).toString(), 'ciphertext-refs-v1');
+        // …and it landed under the account's own key prefix.
+        deepEqual([...s3.objects.keys()], ['alice.near/refs']);
+    });
+
+    test('stale refs CAS is rejected with 412', async () => {
+        const res = await fetch(`${base}/alice.near/refs`, {
+            method: 'PUT',
+            headers: { ...asAlice, 'if-match': '"stale"', 'content-type': 'application/octet-stream' },
+            body: Buffer.from('clobber'),
+        });
+        equal(res.status, 412);
+        equal(s3.objects.get('alice.near/refs').body.toString(), 'ciphertext-refs-v1');
+    });
+});


### PR DESCRIPTION
Gateway side of **arizas/Ariz-Portfolio#76** — the zero-knowledge storage backend for client-side encrypted git repos.

## What
- [`encrypted-git-storage`](https://github.com/petersalomonsen/encrypted-git-storage) v0.1.1 (git dependency) `createProxy` mounted at **`/store`**:
  - **NEP-413 auth**, `repoId = the authenticated account` → a caller only ever reaches their own `<account>/*` objects (same model as `/git`), billing-gated like `/git`.
  - The gateway **only ever sees ciphertext** — every packfile and the refs manifest are AES-256-GCM encrypted client-side (service worker / `git-remote-egit`) before upload.
- **CORS** for `https://arizportfolio.near.page` (override: `ARIZ_STORE_ALLOWED_ORIGINS`). The app page is web4-served and web4 can only proxy GETs, so the service worker PUTs to this origin directly; `OPTIONS` preflights carry no `Authorization` header by spec and bypass auth (answered by the proxy, with `ETag` exposed for the refs CAS).
- **S3 backend from env**: Tigris' `AWS_*`/`BUCKET_NAME` (what `fly storage create` sets) or `S3_*` (dev/MinIO, path-style). When no bucket is configured, `/store` is **disabled with a log line** — the gateway keeps running, so this is safe to merge before provisioning.
- **Node 20 → 22** (Dockerfile + CI): the library requires ≥22, and Node 20 is EOL.

## Tests
`server/store.test.js` (in-memory fake S3, no MinIO needed in this repo's CI — the library's own CI covers real S3 semantics against MinIO, including browser↔CLI interop):
- preflight answered without auth (204 + CORS headers)
- unauthenticated → 401; other account's store → 403
- refs round-trip (`If-None-Match: *` create → read) lands under the account's key prefix
- stale `If-Match` CAS → 412, object unchanged

Full suite: **49 passing**.

## Provisioning (after merge)
```sh
fly storage create --app arizgateway   # Tigris bucket; sets AWS_* + BUCKET_NAME secrets
```
Then `/store` activates on the next boot. Follow-ups (frontend, tracked in #76): register `/sw.js` (already served, SW registration proven live on near.page), wallet-derived key, point the confidential repo remote at the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)