### PR TITLE
CORS: reflect requested headers in preflight (Authorization not covered by *)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -75,8 +75,13 @@ const app = express();
 app.use((req, res, next) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
     if (req.method === 'OPTIONS') {
-        res.setHeader('Access-Control-Allow-Headers', '*');
-        res.setHeader('Access-Control-Allow-Methods', '*');
+        // Reflect the requested headers rather than '*': per the Fetch spec the
+        // wildcard does NOT cover Authorization (Firefox/Safari enforce this;
+        // Chrome is lenient), and every authenticated call — /api, /git, /store —
+        // sends it. Reflecting also covers If-Match/If-None-Match for the /store
+        // refs CAS.
+        res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] ?? '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
         res.end();
         return;
     }


### PR DESCRIPTION
Per the Fetch spec, `Access-Control-Allow-Headers: *` does **not** cover `Authorization` — it must be listed explicitly. Chrome is lenient (why the app has worked), but Firefox/Safari enforce it, which would break every authenticated cross-origin call (`/api`, `/git`, and the new `/store`) from `arizportfolio.near.page`. Reflecting the preflight's `Access-Control-Request-Headers` fixes all of them, and also covers `If-Match`/`If-None-Match` for the /store refs CAS.

Found while verifying the /store CORS path (#37 follow-up, arizas/Ariz-Portfolio#76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)