### PR TITLE
store: blind account identities in object keys (HMAC ids + /store/me alias)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ import { createAuthMiddleware } from './accesscontrol/middleware.js';
 import { createRpcHandler } from './rpc.js';
 import { createGitHandler } from './git.js';
 import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+import { makeStoreRepoId } from './store-id.js';
 import { S3Client } from '@aws-sdk/client-s3';
 import { createRouter as createAccountingRouter, startWorker as startAccountingWorker } from 'near-accounting-export';
 import { createDeductClient } from './arizcredits/deduct.js';
@@ -201,11 +202,18 @@ if (storeBucket && storeEndpoint) {
             },
         } : {}),
     });
+    // Blinded per-account store ids (see server/store-id.js): object keys are
+    // HMAC(secret, account), so the bucket reveals no account identities. Clients
+    // address their own store as /store/me/… — rewritten after authentication.
+    const storeRepoId = makeStoreRepoId(process.env.ARIZ_STORE_ID_SECRET);
+    if (!process.env.ARIZ_STORE_ID_SECRET) {
+        console.warn('encrypted store: ARIZ_STORE_ID_SECRET not set — store ids are plain account names');
+    }
     const storeProxy = createStoreProxy({
         s3: storeS3,
         bucket: storeBucket,
         allowedOrigins: splitList(process.env.ARIZ_STORE_ALLOWED_ORIGINS ?? 'https://arizportfolio.near.page'),
-        auth: (req) => req.accountId ?? null,
+        auth: (req) => req.storeRepoId ?? null,
     });
     app.use('/store', (req, res, next) => {
         // CORS preflights carry no Authorization header by spec — the proxy
@@ -223,10 +231,15 @@ if (storeBucket && storeEndpoint) {
                     });
                 }
             }
+            req.storeRepoId = storeRepoId(req.accountId);
+            // `me` alias — clients can't compute their blinded id themselves.
+            if (req.url === '/me' || req.url.startsWith('/me/')) {
+                req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
+            }
             storeProxy(req, res, next);
         });
     });
-    console.log(`encrypted store: /store -> ${storeEndpoint} bucket=${storeBucket}`);
+    console.log(`encrypted store: /store -> ${storeEndpoint} bucket=${storeBucket} (blinded ids: ${process.env.ARIZ_STORE_ID_SECRET ? 'on' : 'OFF'})`);
 } else {
     console.log('encrypted store: disabled (set BUCKET_NAME + AWS_ENDPOINT_URL_S3, or S3_BUCKET + S3_ENDPOINT)');
 }

--- a/server/store-id.js
+++ b/server/store-id.js
@@ -1,0 +1,20 @@
+import { createHmac } from 'node:crypto';
+
+// Blinded store ids: the encrypted store's object keys use
+// HMAC-SHA256(secret, accountId) instead of the account name, so someone with
+// bucket-level access (storage provider staff, a leaked bucket credential)
+// cannot map objects back to NEAR accounts. A plain unkeyed hash would not do:
+// account names are public and enumerable, so it falls to a dictionary attack.
+//
+// The secret (ARIZ_STORE_ID_SECRET) must stay stable: changing it orphans every
+// existing store (the mapping to the old prefixes is lost). Keep it a Fly
+// secret; never write it to the bucket.
+//
+// Clients can't compute their own id (they don't hold the secret), so the
+// /store router accepts the literal segment `me` and rewrites it to the
+// authenticated account's id after NEP-413 auth.
+export function makeStoreRepoId(secret) {
+    if (!secret) return (accountId) => accountId; // blinding off (dev/tests)
+    return (accountId) =>
+        'r' + createHmac('sha256', secret).update(String(accountId)).digest('hex').slice(0, 32);
+}

--- a/server/store.test.js
+++ b/server/store.test.js
@@ -1,7 +1,8 @@
 import { test, before, after, describe } from 'node:test';
-import { equal, deepEqual, ok } from 'node:assert/strict';
+import { equal, deepEqual, ok, notEqual, match } from 'node:assert/strict';
 import express from 'express';
 import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+import { makeStoreRepoId } from './store-id.js';
 
 // Wiring tests for the /store mount (encrypted-git-storage): NEP-413-style auth
 // scoping (repoId = authenticated account), the unauthenticated CORS preflight
@@ -49,23 +50,31 @@ const ORIGIN = 'https://arizportfolio.near.page';
 describe('encrypted store mount (/store)', () => {
     let server, base, s3;
 
+    const storeRepoId = makeStoreRepoId('test-blinding-secret');
+    const aliceId = storeRepoId('alice.near');
+
     before(async () => {
         s3 = fakeS3();
         const storeProxy = createStoreProxy({
             s3,
             bucket: 'test',
             allowedOrigins: [ORIGIN],
-            auth: (req) => req.accountId ?? null,
+            auth: (req) => req.storeRepoId ?? null,
         });
         const app = express();
         // Same composition as server/index.js: OPTIONS bypasses auth (a CORS
         // preflight carries no Authorization header); everything else must
-        // authenticate. Auth is stubbed like git.test.js: account from a header.
+        // authenticate (stubbed like git.test.js: account from a header), gets a
+        // blinded store id, and may address itself as /store/me/….
         app.use('/store', (req, res, next) => {
             if (req.method === 'OPTIONS') return storeProxy(req, res, next);
             const account = req.headers['x-test-account'];
             if (!account) return res.status(401).send('failed to parse token');
             req.accountId = account;
+            req.storeRepoId = storeRepoId(account);
+            if (req.url === '/me' || req.url.startsWith('/me/')) {
+                req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
+            }
             storeProxy(req, res, next);
         });
         await new Promise((r) => { server = app.listen(0, r); });
@@ -95,32 +104,54 @@ describe('encrypted store mount (/store)', () => {
         equal((await fetch(`${base}/alice.near/refs`)).status, 401);
     });
 
-    test('an account only reaches its own store (repoId = account)', async () => {
+    test('an account only reaches its own store (blinded ids)', async () => {
+        // Neither another account's plain name nor its blinded id is reachable.
         equal((await fetch(`${base}/bob.near/refs`, { headers: asAlice })).status, 403);
+        equal((await fetch(`${base}/${storeRepoId('bob.near')}/refs`, { headers: asAlice })).status, 403);
+        // The plain own account name no longer addresses the store either.
+        equal((await fetch(`${base}/alice.near/refs`, { headers: asAlice })).status, 403);
     });
 
-    test('refs round-trip: create (If-None-Match) then read back', async () => {
-        const put = await fetch(`${base}/alice.near/refs`, {
+    test('refs round-trip via the /me alias, keys land under the blinded prefix', async () => {
+        const put = await fetch(`${base}/me/refs`, {
             method: 'PUT',
             headers: { ...asAlice, 'if-none-match': '*', 'content-type': 'application/octet-stream' },
             body: Buffer.from('ciphertext-refs-v1'),
         });
         equal(put.status, 204);
 
-        const get = await fetch(`${base}/alice.near/refs`, { headers: asAlice });
+        // Readable via the alias and via the literal blinded id.
+        const get = await fetch(`${base}/me/refs`, { headers: asAlice });
         equal(get.status, 200);
         equal(Buffer.from(await get.arrayBuffer()).toString(), 'ciphertext-refs-v1');
-        // …and it landed under the account's own key prefix.
-        deepEqual([...s3.objects.keys()], ['alice.near/refs']);
+        equal((await fetch(`${base}/${aliceId}/refs`, { headers: asAlice })).status, 200);
+
+        // The bucket sees only the blinded prefix — no account name anywhere.
+        deepEqual([...s3.objects.keys()], [`${aliceId}/refs`]);
+        ok(!aliceId.includes('alice'), 'blinded id must not contain the account name');
     });
 
     test('stale refs CAS is rejected with 412', async () => {
-        const res = await fetch(`${base}/alice.near/refs`, {
+        const res = await fetch(`${base}/me/refs`, {
             method: 'PUT',
             headers: { ...asAlice, 'if-match': '"stale"', 'content-type': 'application/octet-stream' },
             body: Buffer.from('clobber'),
         });
         equal(res.status, 412);
-        equal(s3.objects.get('alice.near/refs').body.toString(), 'ciphertext-refs-v1');
+        equal(s3.objects.get(`${aliceId}/refs`).body.toString(), 'ciphertext-refs-v1');
+    });
+});
+
+describe('store-id blinding (makeStoreRepoId)', () => {
+    test('keyed, deterministic, and account-name-free', () => {
+        const id = makeStoreRepoId('s1');
+        equal(id('alice.near'), id('alice.near'));
+        notEqual(id('alice.near'), id('bob.near'));
+        notEqual(makeStoreRepoId('s2')('alice.near'), id('alice.near'), 'different secret -> different id');
+        match(id('alice.near'), /^r[0-9a-f]{32}$/);
+    });
+
+    test('no secret -> identity (blinding off for dev/tests)', () => {
+        equal(makeStoreRepoId(undefined)('alice.near'), 'alice.near');
     });
 });


### PR DESCRIPTION
Privacy hardening for the encrypted store (#37 follow-up, arizas/Ariz-Portfolio#76): object keys no longer reveal account identities to bucket-level observers.

- **Keys are `HMAC-SHA256(ARIZ_STORE_ID_SECRET, account)`** (`r` + 32 hex): a Tigris-side observer or leaked bucket credential sees only unlinkable prefixes + sizes/timing. A plain hash would be dictionary-reversible (account names are public/enumerable), hence keyed.
- **`/store/me/…` alias**: clients can't compute their blinded id, so the router rewrites `me` after NEP-413 auth. The SW (`storeBaseUrl: …/store/me`) and CLI (`egit::…/store/me`) need no id knowledge. The literal blinded id also works.
- Scope honesty: this blinds the **storage layer**. The gateway itself necessarily knows the account at request time (it authenticates it) — contents are protected by the client-side AES encryption regardless.
- No secret set → plain account ids + startup warning (dev/tests unchanged).
- **The secret must stay stable** — rotating orphans existing stores. Set in prod already (`fly secrets set`); the store is empty, so this is the right moment (no migration).

Tests: blinded round-trip via `/me`, cross-account 403s (plain name + blinded id + own plain name), keys land under the blinded prefix, `makeStoreRepoId` unit tests. **51 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)