### PR TITLE
store: key-wrap storage (keys/<wrapId>) + extract the mount into store-mount.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,8 +12,8 @@ import {
 import { createAuthMiddleware } from './accesscontrol/middleware.js';
 import { createRpcHandler } from './rpc.js';
 import { createGitHandler } from './git.js';
-import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
 import { makeStoreRepoId } from './store-id.js';
+import { createStoreMount } from './store-mount.js';
 import { S3Client } from '@aws-sdk/client-s3';
 import { createRouter as createAccountingRouter, startWorker as startAccountingWorker } from 'near-accounting-export';
 import { createDeductClient } from './arizcredits/deduct.js';
@@ -209,41 +209,14 @@ if (storeBucket && storeEndpoint) {
     if (!process.env.ARIZ_STORE_ID_SECRET) {
         console.warn('encrypted store: ARIZ_STORE_ID_SECRET not set — store ids are plain account names');
     }
-    const storeProxy = createStoreProxy({
+    app.use('/store', createStoreMount({
         s3: storeS3,
         bucket: storeBucket,
         allowedOrigins: splitList(process.env.ARIZ_STORE_ALLOWED_ORIGINS ?? 'https://arizportfolio.near.page'),
-        auth: (req) => req.storeRepoId ?? null,
-    });
-    app.use('/store', (req, res, next) => {
-        // CORS preflights carry no Authorization header by spec — the proxy
-        // answers them; everything else authenticates first.
-        if (req.method === 'OPTIONS') return storeProxy(req, res, next);
-        auth(req, res, async () => {
-            // Billing gates WRITES only. Reads (clone/fetch of the caller's own
-            // encrypted data) stay available to lapsed accounts: a user's backup
-            // must never be hostage to their ARIZ balance. The store is a
-            // convenience sync target — users keep custody of their data — but
-            // getting it back out is always free.
-            if (accountGate && req.method !== 'GET' && req.method !== 'HEAD') {
-                let authorized = false;
-                try { authorized = await accountGate(req.accountId); } catch { authorized = false; } // fail closed
-                if (!authorized) {
-                    return res.status(402).json({
-                        error: 'authorization_required',
-                        accountId: req.accountId,
-                        message: 'Writing to the encrypted store requires an account that has authorized the gateway (authorize_deduction on arizcredits.near) and holds ARIZ. Reading your existing data remains available.',
-                    });
-                }
-            }
-            req.storeRepoId = storeRepoId(req.accountId);
-            // `me` alias — clients can't compute their blinded id themselves.
-            if (req.url === '/me' || req.url.startsWith('/me/')) {
-                req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
-            }
-            storeProxy(req, res, next);
-        });
-    });
+        auth,
+        accountGate,
+        storeRepoId,
+    }));
     console.log(`encrypted store: /store -> ${storeEndpoint} bucket=${storeBucket} (blinded ids: ${process.env.ARIZ_STORE_ID_SECRET ? 'on' : 'OFF'})`);
 } else {
     console.log('encrypted store: disabled (set BUCKET_NAME + AWS_ENDPOINT_URL_S3, or S3_BUCKET + S3_ENDPOINT)');

--- a/server/store-mount.js
+++ b/server/store-mount.js
@@ -1,0 +1,88 @@
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+
+/**
+ * The /store mount: encrypted-git-storage proxy + Ariz policy, composed once and
+ * shared by server/index.js and the tests (so what's tested is what runs).
+ *
+ *  - CORS preflights bypass auth (they carry no Authorization header by spec).
+ *  - `auth` (express middleware) authenticates and sets req.accountId.
+ *  - Billing (`accountGate`) gates WRITES only: reads of the caller's own
+ *    encrypted data stay available to lapsed accounts — a backup is never
+ *    hostage to billing.
+ *  - `storeRepoId(account)` blinds the account into the object-key prefix; the
+ *    `me` alias is rewritten after auth (clients can't compute their own id).
+ *  - `keys/<wrapId>`: consumer-side key management (arizas/Ariz-Portfolio#76) —
+ *    small AES-GCM wraps of the repo master key, one per enrolled wallet key,
+ *    named by an HKDF id derived from the wallet signature (NOT a public-key
+ *    fingerprint: access keys are public on-chain and pk-named blobs would
+ *    de-blind the store). Immutable create-only; enrollment races resolve via 412.
+ */
+export function createStoreMount({ s3, bucket, allowedOrigins, auth, accountGate, storeRepoId }) {
+    const storeProxy = createStoreProxy({
+        s3,
+        bucket,
+        allowedOrigins,
+        auth: (req) => req.storeRepoId ?? null,
+    });
+
+    return function storeMount(req, res, next) {
+        if (req.method === 'OPTIONS') return storeProxy(req, res, next);
+        auth(req, res, async () => {
+            try {
+                if (accountGate && req.method !== 'GET' && req.method !== 'HEAD') {
+                    let authorized = false;
+                    try { authorized = await accountGate(req.accountId); } catch { authorized = false; } // fail closed
+                    if (!authorized) {
+                        return res.status(402).json({
+                            error: 'authorization_required',
+                            accountId: req.accountId,
+                            message: 'Writing to the encrypted store requires an account that has authorized the gateway (authorize_deduction on arizcredits.near) and holds ARIZ. Reading your existing data remains available.',
+                        });
+                    }
+                }
+                req.storeRepoId = storeRepoId(req.accountId);
+                if (req.url === '/me' || req.url.startsWith('/me/')) {
+                    req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
+                }
+
+                const wrapMatch = req.url.match(/^\/([^/]+)\/keys\/([0-9a-f]{32,64})$/);
+                if (wrapMatch) {
+                    if (wrapMatch[1] !== req.storeRepoId) return res.status(403).json({ error: 'forbidden' });
+                    const key = `${req.storeRepoId}/keys/${wrapMatch[2]}`;
+                    try {
+                        if (req.method === 'GET') {
+                            const r = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+                            return res.type('application/octet-stream').send(Buffer.from(await r.Body.transformToByteArray()));
+                        }
+                        if (req.method === 'PUT') {
+                            // Read the (small) wrap body directly — a mount-level raw
+                            // parser would consume/limit the proxy's pack uploads.
+                            const chunks = [];
+                            let size = 0;
+                            for await (const c of req) {
+                                size += c.length;
+                                if (size > 64 * 1024) return res.status(413).json({ error: 'wrap too large' });
+                                chunks.push(c);
+                            }
+                            await s3.send(new PutObjectCommand({
+                                Bucket: bucket, Key: key, Body: Buffer.concat(chunks), IfNoneMatch: '*',
+                            }));
+                            return res.status(204).end();
+                        }
+                        return res.status(405).json({ error: 'method not allowed' });
+                    } catch (e) {
+                        const status = e?.$metadata?.httpStatusCode;
+                        if (status === 404 || e?.name === 'NoSuchKey') return res.status(404).json({ error: 'not found' });
+                        if (status === 412 || e?.name === 'PreconditionFailed') return res.status(412).json({ error: 'wrap already exists' });
+                        throw e;
+                    }
+                }
+
+                storeProxy(req, res, next);
+            } catch (e) {
+                next(e);
+            }
+        });
+    };
+}

--- a/server/store.test.js
+++ b/server/store.test.js
@@ -1,13 +1,15 @@
 import { test, before, after, describe } from 'node:test';
 import { equal, deepEqual, ok, notEqual, match } from 'node:assert/strict';
 import express from 'express';
-import { createProxy as createStoreProxy } from 'encrypted-git-storage/gateway';
+import { createStoreMount } from './store-mount.js';
 import { makeStoreRepoId } from './store-id.js';
 
-// Wiring tests for the /store mount (encrypted-git-storage): NEP-413-style auth
-// scoping (repoId = authenticated account), the unauthenticated CORS preflight
-// bypass, and a refs round-trip — against an in-memory fake S3, so no MinIO is
-// needed in this repo's CI (the library's own CI covers the real S3 semantics).
+// Tests drive the REAL /store composition (server/store-mount.js — the same
+// module index.js mounts): NEP-413-style auth scoping via blinded ids, the
+// unauthenticated CORS preflight bypass, the /me alias, the writes-only billing
+// gate, key wraps, and refs round-trips — against an in-memory fake S3, so no
+// MinIO is needed in this repo's CI (the library's own CI covers real S3
+// semantics).
 function fakeS3() {
     const objects = new Map(); // key -> { body: Buffer, etag: string }
     let etagCounter = 0;
@@ -47,46 +49,39 @@ function fakeS3() {
 
 const ORIGIN = 'https://arizportfolio.near.page';
 
-describe('encrypted store mount (/store)', () => {
-    let server, base, s3;
+// Auth stub with the same contract as the real middleware: sets req.accountId or
+// responds 401 (like git.test.js, the account comes from a header).
+function stubAuth(req, res, next) {
+    const account = req.headers['x-test-account'];
+    if (!account) return res.status(401).send('failed to parse token');
+    req.accountId = account;
+    next();
+}
 
+async function startMount({ accountGate = null } = {}) {
+    const s3 = fakeS3();
     const storeRepoId = makeStoreRepoId('test-blinding-secret');
-    const aliceId = storeRepoId('alice.near');
+    const app = express();
+    app.use('/store', createStoreMount({
+        s3, bucket: 'test', allowedOrigins: [ORIGIN], auth: stubAuth, accountGate, storeRepoId,
+    }));
+    const server = await new Promise((r) => { const s = app.listen(0, () => r(s)); });
+    return { s3, storeRepoId, server, base: `http://localhost:${server.address().port}/store` };
+}
+
+const asAlice = { 'x-test-account': 'alice.near' };
+
+describe('encrypted store mount (/store)', () => {
+    let s3, storeRepoId, server, base, aliceId;
 
     before(async () => {
-        s3 = fakeS3();
-        const storeProxy = createStoreProxy({
-            s3,
-            bucket: 'test',
-            allowedOrigins: [ORIGIN],
-            auth: (req) => req.storeRepoId ?? null,
-        });
-        const app = express();
-        // Same composition as server/index.js: OPTIONS bypasses auth (a CORS
-        // preflight carries no Authorization header); everything else must
-        // authenticate (stubbed like git.test.js: account from a header), gets a
-        // blinded store id, and may address itself as /store/me/….
-        app.use('/store', (req, res, next) => {
-            if (req.method === 'OPTIONS') return storeProxy(req, res, next);
-            const account = req.headers['x-test-account'];
-            if (!account) return res.status(401).send('failed to parse token');
-            req.accountId = account;
-            req.storeRepoId = storeRepoId(account);
-            if (req.url === '/me' || req.url.startsWith('/me/')) {
-                req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
-            }
-            storeProxy(req, res, next);
-        });
-        await new Promise((r) => { server = app.listen(0, r); });
-        base = `http://localhost:${server.address().port}/store`;
+        ({ s3, storeRepoId, server, base } = await startMount());
+        aliceId = storeRepoId('alice.near');
     });
-
     after(() => server?.close());
 
-    const asAlice = { 'x-test-account': 'alice.near' };
-
     test('CORS preflight is answered without authentication', async () => {
-        const res = await fetch(`${base}/alice.near/refs`, {
+        const res = await fetch(`${base}/me/refs`, {
             method: 'OPTIONS',
             headers: {
                 Origin: ORIGIN,
@@ -101,14 +96,13 @@ describe('encrypted store mount (/store)', () => {
     });
 
     test('unauthenticated requests are rejected', async () => {
-        equal((await fetch(`${base}/alice.near/refs`)).status, 401);
+        equal((await fetch(`${base}/me/refs`)).status, 401);
     });
 
     test('an account only reaches its own store (blinded ids)', async () => {
-        // Neither another account's plain name nor its blinded id is reachable.
         equal((await fetch(`${base}/bob.near/refs`, { headers: asAlice })).status, 403);
         equal((await fetch(`${base}/${storeRepoId('bob.near')}/refs`, { headers: asAlice })).status, 403);
-        // The plain own account name no longer addresses the store either.
+        // The plain own account name doesn't address the store either.
         equal((await fetch(`${base}/alice.near/refs`, { headers: asAlice })).status, 403);
     });
 
@@ -120,13 +114,11 @@ describe('encrypted store mount (/store)', () => {
         });
         equal(put.status, 204);
 
-        // Readable via the alias and via the literal blinded id.
         const get = await fetch(`${base}/me/refs`, { headers: asAlice });
         equal(get.status, 200);
         equal(Buffer.from(await get.arrayBuffer()).toString(), 'ciphertext-refs-v1');
         equal((await fetch(`${base}/${aliceId}/refs`, { headers: asAlice })).status, 200);
 
-        // The bucket sees only the blinded prefix — no account name anywhere.
         deepEqual([...s3.objects.keys()], [`${aliceId}/refs`]);
         ok(!aliceId.includes('alice'), 'blinded id must not contain the account name');
     });
@@ -139,6 +131,62 @@ describe('encrypted store mount (/store)', () => {
         });
         equal(res.status, 412);
         equal(s3.objects.get(`${aliceId}/refs`).body.toString(), 'ciphertext-refs-v1');
+    });
+
+    test('key wraps: create-once, read back, races resolve via 412', async () => {
+        const wrapId = 'a'.repeat(32);
+        equal((await fetch(`${base}/me/keys/${wrapId}`, { headers: asAlice })).status, 404);
+
+        const put = await fetch(`${base}/me/keys/${wrapId}`, {
+            method: 'PUT',
+            headers: { ...asAlice, 'content-type': 'application/octet-stream' },
+            body: Buffer.from('wrapped-dek-ciphertext'),
+        });
+        equal(put.status, 204);
+
+        const get = await fetch(`${base}/me/keys/${wrapId}`, { headers: asAlice });
+        equal(get.status, 200);
+        equal(Buffer.from(await get.arrayBuffer()).toString(), 'wrapped-dek-ciphertext');
+        ok(s3.objects.has(`${aliceId}/keys/${wrapId}`), 'wrap stored under the blinded prefix');
+
+        // Wraps are immutable — a second create (setup race) gets 412.
+        const race = await fetch(`${base}/me/keys/${wrapId}`, {
+            method: 'PUT', headers: { ...asAlice }, body: Buffer.from('other-dek'),
+        });
+        equal(race.status, 412);
+        equal(s3.objects.get(`${aliceId}/keys/${wrapId}`).body.toString(), 'wrapped-dek-ciphertext');
+    });
+
+    test("key wraps: another account's wraps are unreachable", async () => {
+        const wrapId = 'a'.repeat(32);
+        const res = await fetch(`${base}/${storeRepoId('bob.near')}/keys/${wrapId}`, { headers: asAlice });
+        equal(res.status, 403);
+    });
+});
+
+describe('billing gate: reads stay available to lapsed accounts', () => {
+    let server, base;
+
+    before(async () => {
+        // Every account is lapsed/unfunded.
+        ({ server, base } = await startMount({ accountGate: async () => false }));
+    });
+    after(() => server?.close());
+
+    test('lapsed account: writes are 402 (refs, packs, wraps, deletes)', async () => {
+        for (const [path, method] of [['/me/refs', 'PUT'], ['/me/packs/0', 'PUT'], [`/me/keys/${'b'.repeat(32)}`, 'PUT'], ['/me/packs/0', 'DELETE']]) {
+            const res = await fetch(`${base}${path}`, {
+                method, headers: { ...asAlice, 'if-none-match': '*' }, body: method === 'DELETE' ? undefined : Buffer.from('x'),
+            });
+            equal(res.status, 402, `${method} ${path}`);
+        }
+    });
+
+    test('lapsed account: reads reach the store (clone/fetch stays possible)', async () => {
+        // 404 (not 402) proves the request passed the gate and hit the empty store.
+        equal((await fetch(`${base}/me/refs`, { headers: asAlice })).status, 404);
+        equal((await fetch(`${base}/me/packs`, { headers: asAlice })).status, 200);
+        equal((await fetch(`${base}/me/keys/${'b'.repeat(32)}`, { headers: asAlice })).status, 404);
     });
 });
 
@@ -153,65 +201,5 @@ describe('store-id blinding (makeStoreRepoId)', () => {
 
     test('no secret -> identity (blinding off for dev/tests)', () => {
         equal(makeStoreRepoId(undefined)('alice.near'), 'alice.near');
-    });
-});
-
-describe('billing gate: reads stay available to lapsed accounts', () => {
-    let server, base;
-
-    before(async () => {
-        const storeProxy = createStoreProxy({
-            s3: fakeS3(),
-            bucket: 'test',
-            auth: (req) => req.storeRepoId ?? null,
-        });
-        const gate = async () => false; // every account is lapsed/unfunded
-        const id = makeStoreRepoId('gate-secret');
-        const app = express();
-        // Mirrors server/index.js: writes are billing-gated, reads are not — a
-        // user's encrypted backup must never be hostage to their ARIZ balance.
-        app.use('/store', (req, res, next) => {
-            if (req.method === 'OPTIONS') return storeProxy(req, res, next);
-            const account = req.headers['x-test-account'];
-            if (!account) return res.status(401).send('failed to parse token');
-            req.accountId = account;
-            (async () => {
-                if (req.method !== 'GET' && req.method !== 'HEAD') {
-                    if (!(await gate(account))) {
-                        return res.status(402).json({ error: 'authorization_required' });
-                    }
-                }
-                req.storeRepoId = id(account);
-                if (req.url === '/me' || req.url.startsWith('/me/')) {
-                    req.url = `/${req.storeRepoId}${req.url.slice('/me'.length)}`;
-                }
-                storeProxy(req, res, next);
-            })();
-        });
-        await new Promise((r) => { server = app.listen(0, r); });
-        base = `http://localhost:${server.address().port}/store`;
-    });
-
-    after(() => server?.close());
-
-    const asAlice = { 'x-test-account': 'alice.near' };
-
-    test('lapsed account: writes are 402', async () => {
-        const res = await fetch(`${base}/me/refs`, {
-            method: 'PUT',
-            headers: { ...asAlice, 'if-none-match': '*', 'content-type': 'application/octet-stream' },
-            body: Buffer.from('x'),
-        });
-        equal(res.status, 402);
-    });
-
-    test('lapsed account: reads reach the store (clone/fetch stays possible)', async () => {
-        // 404 (not 402) proves the request passed the gate and hit the empty store.
-        equal((await fetch(`${base}/me/refs`, { headers: asAlice })).status, 404);
-        equal((await fetch(`${base}/me/packs`, { headers: asAlice })).status, 200);
-    });
-
-    test('lapsed account: maintenance deletes are gated too', async () => {
-        equal((await fetch(`${base}/me/packs/0`, { method: 'DELETE', headers: asAlice })).status, 402);
     });
 });


### PR DESCRIPTION
Storage half of the wrapped-DEK key model (arizas/Ariz-Portfolio#76 — see the design-review comments there):

- **`GET/PUT /store/me/keys/<wrapId>`** — small AES-GCM wraps of the repo master key (DEK), one per enrolled wallet key. Named by an **HKDF id derived from the wallet signature**, not a pk fingerprint (access keys are public on-chain; pk-named blobs would de-blind the store). **Create-only** (`If-None-Match: *`) so wraps are immutable and first-setup races resolve via 412 — the loser takes the unlock path instead of minting a second DEK.
- Reads free for lapsed accounts (consistent with #41); writes billing-gated. 64KB body cap read directly (a mount-level raw parser would break the proxy's 100MB pack uploads).
- **Refactor:** the full `/store` composition now lives in `server/store-mount.js`, mounted by `index.js` **and** driven directly by the tests — previously the tests hand-copied the composition (three diverging replicas).

Tests now exercise the real mount: preflight, 401/403 blinded scoping, refs round-trip + CAS, wrap create/read/race/isolation, and the writes-only billing gate across refs/packs/wraps/deletes. **55 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)