### PR TITLE
NEP-413-gated /api/intents/config: 1Click API key delivery (Ariz-Portfolio #75)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -114,6 +114,25 @@ app.get('/api/prices/current', auth, async (req, res) => {
     res.end(JSON.stringify(await fetchCurrent(tokens, vs), null, 1));
 });
 
+// 1Click confidential-intents API access (arizas/Ariz-Portfolio#75). The
+// frontend needs the partner x-api-key to call https://1click.chaindefuser.com
+// (auth + confidential history/balances); the key is a gateway secret, handed
+// out only to NEP-413-authenticated users. The actual account authentication
+// against 1Click happens client-side with a wallet-signed NEP-413 message —
+// this key only opens the API channel, it grants no access to other accounts'
+// confidential data.
+const oneClickApiKey = process.env.ONECLICK_API_KEY;
+const oneClickApiUrl = process.env.ONECLICK_API_URL ?? 'https://1click.chaindefuser.com';
+app.get('/api/intents/config', auth, (req, res) => {
+    if (!oneClickApiKey) {
+        return res.status(404).json({
+            error: 'not_configured',
+            message: 'Confidential intents access is not configured on this gateway (ONECLICK_API_KEY is not set).',
+        });
+    }
+    res.json({ apiUrl: oneClickApiUrl, apiKey: oneClickApiKey });
+});
+
 app.post('/rpc', auth, handleRpc);
 
 // Path-based account selection. When billing is on, each monitored account is

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -35,7 +35,9 @@ describe('server', { only: false }, () => {
     let contactAccountKeyPair;
     const serverEnvironment = {
         ARIZ_GATEWAY_PORT: 15000,
-        ARIZ_GATEWAY_NEAR_NETWORK_ID: 'sandbox'
+        ARIZ_GATEWAY_NEAR_NETWORK_ID: 'sandbox',
+        ONECLICK_API_KEY: 'test-oneclick-key',
+        ONECLICK_API_URL: 'https://oneclick.example.test'
     };
 
     before(async () => {
@@ -189,6 +191,34 @@ describe('server', { only: false }, () => {
         const accountsRaw = await readFile(join(serverDataDir, 'accounts.json'), 'utf8');
         const accountsDb = JSON.parse(accountsRaw);
         ok(accountsDb.accounts[otherAccountId], `expected ${otherAccountId} in accounts.json`);
+    });
+
+    test('unauthenticated /api/intents/config is rejected', async () => {
+        const response = await fetch(`${baseUrl()}/api/intents/config`);
+        equal(response.status, 401);
+        equal(await response.text(), 'failed to parse token');
+    });
+
+    test('/api/intents/config with a token signed by a key not on the account is rejected', async () => {
+        const stranger = KeyPair.fromRandom('ed25519');
+        const token = createNep413Token(stranger, contract.accountId, contract.accountId);
+        const response = await fetch(`${baseUrl()}/api/intents/config`, {
+            headers: { 'authorization': `Bearer ${token}` }
+        });
+
+        equal(response.status, 401);
+        equal(await response.text(), 'public key not on account');
+    });
+
+    test('authenticated /api/intents/config returns the 1Click api key and url', async () => {
+        const response = await fetch(`${baseUrl()}/api/intents/config`, {
+            headers: { 'authorization': `Bearer ${authToken()}` }
+        });
+
+        equal(response.status, 200);
+        const body = await response.json();
+        equal(body.apiKey, 'test-oneclick-key');
+        equal(body.apiUrl, 'https://oneclick.example.test');
     });
 
     test('/rpc forwards authenticated request to upstream node', async () => {


### PR DESCRIPTION
Slice 1 of arizas/Ariz-Portfolio#75 — deliver the 1Click partner API key to the app.

The browser needs the `x-api-key` to fetch confidential intents history (both `/v0/auth/authenticate` and `/v0/account/history` require it, and 1Click's CORS allows direct browser calls — the privacy-optimal path: the user's history never transits the gateway). Instead of baking the key into the public bundle, `GET /api/intents/config` returns `{ apiUrl, apiKey }` to NEP-413-authenticated users only.

- Key from `ONECLICK_API_KEY` (Fly secret — `fly secrets set ONECLICK_API_KEY=… -a arizgateway`), URL override `ONECLICK_API_URL` (defaults to `https://1click.chaindefuser.com`).
- `404 not_configured` when the secret is unset, so merging is safe before the secret exists — the app treats it as "confidential history unavailable".
- The key only opens the API channel; account authentication against 1Click happens client-side with a wallet-signed NEP-413 message, so it grants no access to other accounts' confidential data.

Integration tests (sandbox NEP-413 flow, same pattern as the other `/api` endpoints): unauthenticated → 401, stranger key → 401, authenticated → key+url.

Companion app PR: arizas/Ariz-Portfolio#98 (the browser module consuming this endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)