### PR TITLE
Bump near-accounting-export to 62a3664: FT tail-balance reconciliation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,13 @@
   "requires": true,
   "packages": {
     "": {
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1085.0",
         "cgi": "^0.3.1",
         "encrypted-git-storage": "^0.1.4",
         "express": "^4.21.2",
-        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
+        "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#62a3664654f0f223388fe07971c8329eb50b51c7",
         "near-api-js": "^2.1.4"
       },
       "devDependencies": {
@@ -1855,9 +1855,9 @@
     },
     "node_modules/near-accounting-export": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
-      "integrity": "sha512-TPGmvmdYSAG/w/vnGE1JjaYicq/Xm016hqQTZNLj2jUjaJbNhULExR1Be6J623I/7yVa+KsO1r7OJLB7IFD5jQ==",
-      "license": "ISC",
+      "resolved": "git+ssh://git@github.com/PeterSalomonsen/near-accounting-export.git#62a3664654f0f223388fe07971c8329eb50b51c7",
+      "integrity": "sha512-obIiDgHZYx81djEFdLPeSRR8pMkoIF9JrndZlywW1Bv578A6Gmm7fCtUTMtuzu/VMI9ymPDYvaQzZk3k34yA4w==",
+      "license": "MIT",
       "dependencies": {
         "@near-js/jsonrpc-client": "^1.5.0",
         "@near-js/jsonrpc-types": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cgi": "^0.3.1",
     "encrypted-git-storage": "^0.1.4",
     "express": "^4.21.2",
-    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#df2bf01a76be30af6330ad8dc5f5ce6ccab8333d",
+    "near-accounting-export": "github:PeterSalomonsen/near-accounting-export#62a3664654f0f223388fe07971c8329eb50b51c7",
     "near-api-js": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Bumps the `near-accounting-export` pin to [62a3664](https://github.com/PeterSalomonsen/near-accounting-export/commit/62a3664654f0f223388fe07971c8329eb50b51c7) (PeterSalomonsen/near-accounting-export#62): tail-balance reconciliation.

## Why

The transfers-API sync is transfer-driven, so FT balance changes with no `ft_transfer` — burns/redemptions, e.g. stNEAR redeemed via meta-pool — left the ledger ending at a stale pre-burn balance. Real case: petersalomonsen.near showed 287.98 stNEAR against 0 on-chain since 2026-04-28, overstating the portfolio's stNEAR ~2×.

With this bump, the sync worker reconciles each FT token's tail against live `ft_balance_of` for historyComplete accounts (~1 view call per owned FT token per 8h pass) and emits correcting records **dated at the actual change block** via archival bisection — so realizations land on the right date and fiscal year. Probe failures and dating fallbacks are warn-logged, never silent.

## Verification

- Upstream PR #62: CI green (unit + integration); verified against real account data — stNEAR corrected 287.98 → 0 dated at burn block 195928787 (2026-04-28T04:45Z), plus dated NPRO reward accruals and ARIZ billing burns, zero probe failures under production RPC pacing.
- Locally: installed dist confirmed to contain the new reconciler; `createRouter`/`startWorker`/`readFastNearMetrics` import cleanly.

After merge, the Fly auto-deploy picks this up and the next 8h sync pass emits the corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)